### PR TITLE
Add idempotency support for state‑changing endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ node_modules/
 # Test reports
 test-output/
 target/
+# Docker volumes
+docker/mysql/data/
+docker/redis/data/
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: bankingportal-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: bankingapp
+      MYSQL_USER: bankinguser
+      MYSQL_PASSWORD: bankingpass
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./mysql/data:/var/lib/mysql
+      - ./mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
+    command: --default-authentication-plugin=mysql_native_password
+    networks:
+      - banking-network
+
+  redis:
+    image: redis:7-alpine
+    container_name: bankingportal-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./redis/data:/data
+    command: redis-server --appendonly yes
+    networks:
+      - banking-network
+
+networks:
+  banking-network:
+    driver: bridge

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -132,10 +136,6 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-mail</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
@@ -149,6 +149,33 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <release>17</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.6.0.Beta2</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/com/webapp/bankingportal/config/CacheConfig.java
+++ b/src/main/java/com/webapp/bankingportal/config/CacheConfig.java
@@ -20,7 +20,7 @@ public class CacheConfig {
     @Bean
     public CacheManager cacheManager() {
         val cacheManager = new CaffeineCacheManager();
-        cacheManager.setCacheNames(List.of("otpAttempts")); // Define the cache name
+        cacheManager.setCacheNames(List.of("otpAttempts")); // Define the cache names
         cacheManager.setCaffeine(caffeineConfig());
         return cacheManager;
     }

--- a/src/main/java/com/webapp/bankingportal/config/RedisConfig.java
+++ b/src/main/java/com/webapp/bankingportal/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.webapp.bankingportal.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        
+        GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        template.setValueSerializer(jsonSerializer);
+        template.setHashValueSerializer(jsonSerializer);
+        template.afterPropertiesSet();
+
+        return template;
+    }
+}

--- a/src/main/java/com/webapp/bankingportal/controller/AccountController.java
+++ b/src/main/java/com/webapp/bankingportal/controller/AccountController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.cache.annotation.Cacheable;
 import com.webapp.bankingportal.dto.AmountRequest;
 import com.webapp.bankingportal.dto.FundTransferRequest;
 import com.webapp.bankingportal.dto.PinRequest;
@@ -38,6 +39,7 @@ public class AccountController {
     }
 
     @PostMapping("/pin/create")
+    @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/pin/create' + ':' + (#pinRequest).hashCode()")
     public ResponseEntity<String> createPIN(@RequestBody PinRequest pinRequest) {
         accountService.createPin(
                 LoggedinUser.getAccountNumber(),
@@ -48,6 +50,7 @@ public class AccountController {
     }
 
     @PostMapping("/pin/update")
+    @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/pin/update' + ':' + (#pinUpdateRequest).hashCode()")
     public ResponseEntity<String> updatePIN(@RequestBody PinUpdateRequest pinUpdateRequest) {
         accountService.updatePin(
                 LoggedinUser.getAccountNumber(),
@@ -59,6 +62,7 @@ public class AccountController {
     }
 
     @PostMapping("/deposit")
+    @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/deposit' + ':' + (#amountRequest).hashCode()")
     public ResponseEntity<String> cashDeposit(@RequestBody AmountRequest amountRequest) {
         accountService.cashDeposit(
                 LoggedinUser.getAccountNumber(),
@@ -69,6 +73,7 @@ public class AccountController {
     }
 
     @PostMapping("/withdraw")
+    @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/withdraw' + ':' + (#amountRequest).hashCode()")
     public ResponseEntity<String> cashWithdrawal(@RequestBody AmountRequest amountRequest) {
         accountService.cashWithdrawal(
                 LoggedinUser.getAccountNumber(),
@@ -79,6 +84,7 @@ public class AccountController {
     }
 
     @PostMapping("/fund-transfer")
+    @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/fund-transfer' + ':' + (#fundTransferRequest).hashCode()")
     public ResponseEntity<String> fundTransfer(@RequestBody FundTransferRequest fundTransferRequest) {
         accountService.fundTransfer(
                 LoggedinUser.getAccountNumber(),

--- a/src/main/java/com/webapp/bankingportal/service/CacheService.java
+++ b/src/main/java/com/webapp/bankingportal/service/CacheService.java
@@ -1,0 +1,19 @@
+package com.webapp.bankingportal.service;
+
+import com.webapp.bankingportal.type.CacheKeyType;
+import java.util.Optional;
+
+public interface CacheService {
+    
+    boolean exists(CacheKeyType cacheKeyType, String... keyArguments);
+
+    Optional<String> get(CacheKeyType cacheKeyType, String... keyArguments);
+
+    <T> Optional<T> get(CacheKeyType cacheKeyType, Class<T> clazz, String... keyArguments);
+
+    void put(CacheKeyType cacheKeyType, Object value, String... keyArguments);
+
+    void put(CacheKeyType cacheKeyType, Object value, long ttlSeconds, String... keyArguments);
+
+    void delete(CacheKeyType cacheKeyType, String... keyArguments);
+}

--- a/src/main/java/com/webapp/bankingportal/service/CacheServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/CacheServiceImpl.java
@@ -1,0 +1,95 @@
+package com.webapp.bankingportal.service;
+
+import com.webapp.bankingportal.type.CacheKeyType;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CacheServiceImpl implements CacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public boolean exists(CacheKeyType cacheKeyType, String... keyArguments) {
+        return get(cacheKeyType, keyArguments).isPresent();
+    }
+
+    @Override
+    public Optional<String> get(CacheKeyType cacheKeyType, String... keyArguments) {
+        try {
+            String key = acquireKey(cacheKeyType, keyArguments);
+            Object value = redisTemplate.opsForValue().get(key);
+            return Optional.ofNullable(value).map(Object::toString);
+        } catch (Exception e) {
+            log.error("Error retrieving value from cache: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public <T> Optional<T> get(CacheKeyType cacheKeyType, Class<T> clazz, String... keyArguments) {
+        try {
+            String key = acquireKey(cacheKeyType, keyArguments);
+            Object value = redisTemplate.opsForValue().get(key);
+            if (value == null) {
+                return Optional.empty();
+            }
+
+            if (clazz.isInstance(value)) {
+                return Optional.of(clazz.cast(value));
+            }
+
+            log.warn("Value type mismatch. Expected: {}, Actual: {}", clazz.getSimpleName(), value.getClass().getSimpleName());
+            return Optional.empty();
+        } catch (Exception e) {
+            log.error("Error retrieving value from cache: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void put(CacheKeyType cacheKeyType, Object value, String... keyArguments) {
+        put(cacheKeyType, value, cacheKeyType.getTtlSeconds(), keyArguments);
+    }
+
+    @Override
+    public void put(CacheKeyType cacheKeyType, Object value, long ttlSeconds, String... keyArguments) {
+        String key = acquireKey(cacheKeyType, keyArguments);
+
+        try {
+            redisTemplate.opsForValue().set(key, value, ttlSeconds, TimeUnit.SECONDS);
+            log.debug("Cache stored: key={}", key);
+        } catch (Exception e) {
+            log.error("Error storing value in cache: {}", e.getMessage());
+            throw new RuntimeException("Failed to store value in cache", e);
+        }
+    }
+
+    @Override
+    public void delete(CacheKeyType cacheKeyType, String... keyArguments) {
+        String key = acquireKey(cacheKeyType, keyArguments);
+
+        try {
+            redisTemplate.delete(key);
+            log.debug("Cache deleted: key={}", key);
+        } catch (Exception e) {
+            log.error("Error deleting key from cache: {}", e.getMessage());
+        }
+    }
+
+    private String acquireKey(CacheKeyType cacheKeyType, String... keyArguments) {
+        String key = cacheKeyType.generateKey();
+        if (keyArguments.length != 0) {
+            key = cacheKeyType.generateKey(keyArguments);
+        }
+
+        return key;
+    }
+}

--- a/src/main/java/com/webapp/bankingportal/type/CacheKeyType.java
+++ b/src/main/java/com/webapp/bankingportal/type/CacheKeyType.java
@@ -1,0 +1,23 @@
+package com.webapp.bankingportal.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheKeyType {
+    IDEMPOTENCY("IDPT:%s:%s:%s", 86400, CacheValueType.JSON),
+    ;
+
+    private final String prefix;
+    private final long ttlSeconds;
+    private final CacheValueType cacheValueType;
+
+    public String generateKey() {
+        return prefix;
+    }
+
+    public String generateKey(String... arguments) {
+        return String.format(prefix, (Object[]) arguments);
+    }
+}

--- a/src/main/java/com/webapp/bankingportal/type/CacheValueType.java
+++ b/src/main/java/com/webapp/bankingportal/type/CacheValueType.java
@@ -1,0 +1,7 @@
+package com.webapp.bankingportal.type;
+
+public enum CacheValueType {
+    STRING,
+    JSON,
+    ;
+}

--- a/src/test/java/com/webapp/bankingportal/CacheServiceTests.java
+++ b/src/test/java/com/webapp/bankingportal/CacheServiceTests.java
@@ -1,0 +1,170 @@
+package com.webapp.bankingportal;
+
+import com.webapp.bankingportal.service.CacheService;
+import com.webapp.bankingportal.service.CacheServiceImpl;
+import com.webapp.bankingportal.type.CacheKeyType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CacheServiceTests {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    private CacheService cacheService;
+
+    @BeforeEach
+    void setUp() {
+        cacheService = new CacheServiceImpl(redisTemplate);
+    }
+
+    @Test
+    void testExists_WithIdempotencyKey_ReturnsTrue() {
+        String userId = "user123";
+        String endpoint = "/api/account/deposit";
+        String payloadHash = "payload123";
+        String expectedKey = "IDPT:user123:/api/account/deposit:payload123";
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(expectedKey)).thenReturn("cached-response");
+
+        boolean exists = cacheService.exists(CacheKeyType.IDEMPOTENCY, userId, endpoint, payloadHash);
+
+        assertTrue(exists);
+        verify(valueOperations).get(expectedKey);
+    }
+
+    @Test
+    void testExists_WithIdempotencyKey_ReturnsFalse() {
+        String userId = "user123";
+        String endpoint = "/api/account/deposit";
+        String payloadHash = "payload123";
+        String expectedKey = "IDPT:user123:/api/account/deposit:payload123";
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(expectedKey)).thenReturn(null);
+
+        boolean exists = cacheService.exists(CacheKeyType.IDEMPOTENCY, userId, endpoint, payloadHash);
+
+        assertFalse(exists);
+        verify(valueOperations).get(expectedKey);
+    }
+
+    @Test
+    void testGet_WithIdempotencyKey_ReturnsValue() {
+        String userId = "user123";
+        String endpoint = "/api/account/deposit";
+        String payloadHash = "payload123";
+        String expectedKey = "IDPT:user123:/api/account/deposit:payload123";
+        String expectedValue = "test-value";
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(expectedKey)).thenReturn(expectedValue);
+
+        Optional<String> value = cacheService.get(CacheKeyType.IDEMPOTENCY, userId, endpoint, payloadHash);
+
+        assertTrue(value.isPresent());
+        assertEquals(expectedValue, value.get());
+        verify(valueOperations).get(expectedKey);
+    }
+
+    @Test
+    void testGet_WithIdempotencyKey_ReturnsEmpty() {
+        String userId = "user123";
+        String endpoint = "/api/account/deposit";
+        String payloadHash = "payload123";
+        String expectedKey = "IDPT:user123:/api/account/deposit:payload123";
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(expectedKey)).thenReturn(null);
+
+        Optional<String> value = cacheService.get(CacheKeyType.IDEMPOTENCY, userId, endpoint, payloadHash);
+
+        assertTrue(value.isEmpty());
+        verify(valueOperations).get(expectedKey);
+    }
+
+    @Test
+    void testGet_WithClass_WhenValueMatchesType_ReturnsValue() {
+        String userId = "user123";
+        String endpoint = "/api/account/deposit";
+        String payloadHash = "payload123";
+        String expectedKey = "IDPT:user123:/api/account/deposit:payload123";
+        String expectedValue = "test-value";
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(expectedKey)).thenReturn(expectedValue);
+
+        Optional<String> value = cacheService.get(CacheKeyType.IDEMPOTENCY, String.class, userId, endpoint, payloadHash);
+
+        assertTrue(value.isPresent());
+        assertEquals(expectedValue, value.get());
+        verify(valueOperations).get(expectedKey);
+    }
+
+    @Test
+    void testGet_WithClass_WhenValueDoesNotMatchType_ReturnsEmpty() {
+        String userId = "user123";
+        String endpoint = "/api/account/deposit";
+        String payloadHash = "payload123";
+        String expectedKey = "IDPT:user123:/api/account/deposit:payload123";
+        Integer wrongTypeValue = 123;
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(expectedKey)).thenReturn(wrongTypeValue);
+
+        Optional<String> value = cacheService.get(CacheKeyType.IDEMPOTENCY, String.class, userId, endpoint, payloadHash);
+
+        assertTrue(value.isEmpty());
+        verify(valueOperations).get(expectedKey);
+    }
+
+    @Test
+    void testPut_WithIdempotencyKey_StoresValue() {
+        String userId = "user123";
+        String endpoint = "/api/account/deposit";
+        String payloadHash = "payload123";
+        String expectedKey = "IDPT:user123:/api/account/deposit:payload123";
+        String value = "test-value";
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        cacheService.put(CacheKeyType.IDEMPOTENCY, value, userId, endpoint, payloadHash);
+
+        verify(valueOperations).set(expectedKey, value, 86400, java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testPut_WithCustomTtl_StoresValueWithCustomTtl() {
+        String userId = "user123";
+        String endpoint = "/api/account/deposit";
+        String payloadHash = "payload123";
+        String expectedKey = "IDPT:user123:/api/account/deposit:payload123";
+        String value = "test-value";
+        long customTtl = 3600;
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        cacheService.put(CacheKeyType.IDEMPOTENCY, value, customTtl, userId, endpoint, payloadHash);
+
+        verify(valueOperations).set(expectedKey, value, customTtl, java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testDelete_WithIdempotencyKey_DeletesCorrectKey() {
+        String userId = "user123";
+        String endpoint = "/api/account/deposit";
+        String payloadHash = "payload123";
+        String expectedKey = "IDPT:user123:/api/account/deposit:payload123";
+
+        cacheService.delete(CacheKeyType.IDEMPOTENCY, userId, endpoint, payloadHash);
+
+        verify(redisTemplate).delete(expectedKey);
+    }
+}


### PR DESCRIPTION
## Changes
- Used with Spring's standard `@Cacheable` annotation
- Simplified idempotency implementation using built-in caching mechanism
- Maintained same key structure: `userId:endpoint:payloadHash`

## Benefits
- Reduced code complexity and maintenance overhead
- Leverages Spring's proven caching framework
- Cleaner and more standard approach

Related Ticket: #46