### PR TITLE
fix: Add RedisConnectionFailureException handler in GlobalExceptionHandler

### DIFF
--- a/src/main/java/com/webapp/bankingportal/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/webapp/bankingportal/controller/GlobalExceptionHandler.java
@@ -23,6 +23,8 @@ import com.webapp.bankingportal.exception.PasswordResetException;
 import com.webapp.bankingportal.exception.UnauthorizedException;
 import com.webapp.bankingportal.exception.UserInvalidException;
 import org.springframework.data.redis.RedisConnectionFailureException;
+import java.util.Map;
+import com.webapp.bankingportal.util.ApiMessages;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -118,8 +120,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(RedisConnectionFailureException.class)
-    public ResponseEntity<String> handleRedisConnectionFailure(RedisConnectionFailureException ex) {
-        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("{\"message\": \"Cache service unavailable. Please try again.\"}");
+    public ResponseEntity<Map<String, String>> handleRedisConnectionFailure(RedisConnectionFailureException ex) {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(Map.of("message", ApiMessages.REDIS_CONNECTION_FAILURE.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/webapp/bankingportal/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/webapp/bankingportal/controller/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import com.webapp.bankingportal.exception.OtpRetryLimitExceededException;
 import com.webapp.bankingportal.exception.PasswordResetException;
 import com.webapp.bankingportal.exception.UnauthorizedException;
 import com.webapp.bankingportal.exception.UserInvalidException;
+import org.springframework.data.redis.RedisConnectionFailureException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -114,6 +115,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UserInvalidException.class)
     public ResponseEntity<String> handleUserInvalidException(UserInvalidException ex) {
         return ResponseEntity.badRequest().body(ex.getMessage());
+    }
+
+    @ExceptionHandler(RedisConnectionFailureException.class)
+    public ResponseEntity<String> handleRedisConnectionFailure(RedisConnectionFailureException ex) {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("{\"message\": \"Cache service unavailable. Please try again.\"}");
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/webapp/bankingportal/util/ApiMessages.java
+++ b/src/main/java/com/webapp/bankingportal/util/ApiMessages.java
@@ -66,8 +66,8 @@ public enum ApiMessages {
     USER_PHONE_NUMBER_EMPTY_ERROR("Phone number cannot be empty"),
     USER_PHONE_NUMBER_INVALID_ERROR("Invalid phone number: %s for country code: %s"),
     USER_REGISTRATION_SUCCESS("User registered successfully"),
-    USER_UPDATE_SUCCESS("User updated successfully");
-
+    USER_UPDATE_SUCCESS("User updated successfully"),
+    REDIS_CONNECTION_FAILURE("Cache service unavailable. Please try again.");
     @Getter
     private final String message;
 

--- a/src/test/java/com/webapp/bankingportal/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/webapp/bankingportal/GlobalExceptionHandlerTest.java
@@ -1,0 +1,37 @@
+package com.webapp.bankingportal;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.http.MediaType;
+
+import com.webapp.bankingportal.service.AccountService;
+import com.webapp.bankingportal.util.ApiMessages;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public class GlobalExceptionHandlerTest extends BaseTest {
+
+    @MockBean
+    private AccountService accountService;
+
+    @Test
+    void whenRedisConnectionFails_shouldReturn503() throws Exception {
+        // create a real user and login to get a valid token
+        val userDetails = createAndLoginUser();
+        val token = userDetails.get("token");
+
+        // mock AccountService to throw RedisConnectionFailureException
+        Mockito.when(accountService.isPinCreated(Mockito.anyString()))
+               .thenThrow(new RedisConnectionFailureException("Redis down"));
+
+        mockMvc.perform(get("/api/account/pin/check")
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message")
+                .value(ApiMessages.REDIS_CONNECTION_FAILURE.getMessage()));
+    }
+}

--- a/src/test/java/com/webapp/bankingportal/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/webapp/bankingportal/GlobalExceptionHandlerTest.java
@@ -1,5 +1,7 @@
 package com.webapp.bankingportal;
 
+import lombok.val;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -19,11 +21,9 @@ public class GlobalExceptionHandlerTest extends BaseTest {
 
     @Test
     void whenRedisConnectionFails_shouldReturn503() throws Exception {
-        // create a real user and login to get a valid token
         val userDetails = createAndLoginUser();
         val token = userDetails.get("token");
 
-        // mock AccountService to throw RedisConnectionFailureException
         Mockito.when(accountService.isPinCreated(Mockito.anyString()))
                .thenThrow(new RedisConnectionFailureException("Redis down"));
 


### PR DESCRIPTION
## Problem
When Redis is down or unavailable, the app throws a raw 
RedisConnectionFailureException which was not handled, causing 
a 500 response with a full stacktrace leaking to the client.

## Fix
Added a specific handler for RedisConnectionFailureException in 
GlobalExceptionHandler that returns a clean 503 SERVICE_UNAVAILABLE 
response with a user-friendly message instead of exposing internals.

## Changes
- GlobalExceptionHandler.java — added RedisConnectionFailureException handler
