### PR TITLE
Add Comprehensive Docstrings to Codebase issue solution

### DIFF
--- a/src/main/java/com/webapp/bankingportal/BankingportalApplication.java
+++ b/src/main/java/com/webapp/bankingportal/BankingportalApplication.java
@@ -5,13 +5,25 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+/**
+ * Entry point for the Banking Portal Spring Boot application.
+ *
+ * <p>Bootstraps the application with caching ({@link org.springframework.cache.annotation.EnableCaching})
+ * and asynchronous method execution ({@link org.springframework.scheduling.annotation.EnableAsync})
+ * support enabled.</p>
+ */
 @SpringBootApplication
-@EnableCaching // Add this annotation to enable caching support
+@EnableCaching
 @EnableAsync
 public class BankingportalApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BankingportalApplication.class, args);
-	}
+    /**
+     * Application entry point.
+     *
+     * @param args command-line arguments passed to the Spring application context
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(BankingportalApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/webapp/bankingportal/config/CacheConfig.java
+++ b/src/main/java/com/webapp/bankingportal/config/CacheConfig.java
@@ -13,10 +13,23 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 
 import lombok.val;
 
+/**
+ * Spring cache configuration using the Caffeine in-process cache.
+ *
+ * <p>The {@code otpAttempts} cache stores per-account OTP generation attempt counts
+ * with a 15-minute expiry and a maximum of 100 entries. It is used by
+ * {@link com.webapp.bankingportal.service.OtpServiceImpl} to enforce the OTP
+ * rate limit without requiring a database round-trip.</p>
+ */
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
+    /**
+     * Creates and configures the application's primary {@link CacheManager}.
+     *
+     * @return a {@link CaffeineCacheManager} with the {@code otpAttempts} cache pre-registered
+     */
     @Bean
     public CacheManager cacheManager() {
         val cacheManager = new CaffeineCacheManager();
@@ -25,6 +38,12 @@ public class CacheConfig {
         return cacheManager;
     }
 
+    /**
+     * Provides the Caffeine builder used to configure individual caches.
+     *
+     * @return a {@link Caffeine} builder configured with a 15-minute write expiry,
+     *         a maximum size of 100 entries, and statistics recording enabled
+     */
     public Caffeine<Object, Object> caffeineConfig() {
         return Caffeine.newBuilder()
                 .expireAfterWrite(15, TimeUnit.MINUTES) // Cache entries expire after 15 minutes

--- a/src/main/java/com/webapp/bankingportal/config/CorsConfig.java
+++ b/src/main/java/com/webapp/bankingportal/config/CorsConfig.java
@@ -5,9 +5,22 @@ import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * CORS (Cross-Origin Resource Sharing) configuration for the banking portal.
+ *
+ * <p>Allows all origins and all HTTP methods for every endpoint, enabling the
+ * front-end (hosted on a different origin) to communicate with the API without
+ * browser-imposed CORS restrictions.</p>
+ */
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    /**
+     * Registers a global CORS mapping that permits all origins and HTTP methods
+     * for all endpoint patterns.
+     *
+     * @param registry the CORS registry to configure
+     */
     @Override
     public void addCorsMappings(@NonNull CorsRegistry registry) {
         registry.addMapping("/**")

--- a/src/main/java/com/webapp/bankingportal/config/RedisConfig.java
+++ b/src/main/java/com/webapp/bankingportal/config/RedisConfig.java
@@ -10,9 +10,24 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+/**
+ * Redis configuration for the banking portal.
+ *
+ * <p>Configures a {@link RedisTemplate} that uses string serialization for keys and
+ * JSON serialization (via Jackson) for values. The Jackson {@link com.fasterxml.jackson.databind.ObjectMapper}
+ * is configured with {@link com.fasterxml.jackson.datatype.jsr310.JavaTimeModule} to properly
+ * serialize/deserialize Java 8 date/time types.</p>
+ */
 @Configuration
 public class RedisConfig {
 
+    /**
+     * Builds a {@link RedisTemplate} configured for {@code String} keys and
+     * JSON-serialized {@code Object} values.
+     *
+     * @param connectionFactory the Redis connection factory provided by Spring Boot auto-configuration
+     * @return the configured {@link RedisTemplate} bean
+     */
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();

--- a/src/main/java/com/webapp/bankingportal/config/SwaggerConfig.java
+++ b/src/main/java/com/webapp/bankingportal/config/SwaggerConfig.java
@@ -13,9 +13,22 @@ import lombok.val;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * OpenAPI (Swagger) configuration for the banking portal.
+ *
+ * <p>Registers the API metadata and configures a Bearer JWT security scheme
+ * so that the Swagger UI allows developers to authenticate and test secured endpoints
+ * directly from the browser.</p>
+ */
 @Configuration
 public class SwaggerConfig {
 
+    /**
+     * Creates the {@link OpenAPI} bean with API title, description, version,
+     * and a global Bearer token security requirement.
+     *
+     * @return the configured {@link OpenAPI} definition
+     */
     @Bean
     public OpenAPI customOpenAPI() {
         val securitySchemeName = "Bearer";

--- a/src/main/java/com/webapp/bankingportal/config/WebSecurityConfig.java
+++ b/src/main/java/com/webapp/bankingportal/config/WebSecurityConfig.java
@@ -24,12 +24,27 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Spring Security configuration for the banking portal.
+ *
+ * <p>Configures a stateless JWT-based security model:
+ * <ul>
+ *   <li>CSRF protection is disabled (not needed for stateless REST APIs).</li>
+ *   <li>A set of public URLs (registration, login, OTP, Swagger) are accessible
+ *       without authentication.</li>
+ *   <li>All other requests require a valid JWT processed by {@link JwtAuthenticationFilter}.</li>
+ *   <li>Unauthenticated access is handled by {@link JwtAuthenticationEntryPoint}.</li>
+ *   <li>Sessions are never created (STATELESS policy).</li>
+ * </ul>
+ * </p>
+ */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class WebSecurityConfig {
 
+    /** URL patterns that do not require a JWT. */
     private static final String[] PUBLIC_URLS = {
             "/api/users/register",
             "/api/users/login",
@@ -48,16 +63,36 @@ public class WebSecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final TokenService tokenService;
 
+    /**
+     * Wires the {@link TokenService} (which implements {@link org.springframework.security.core.userdetails.UserDetailsService})
+     * and the BCrypt password encoder into the global authentication manager.
+     *
+     * @param auth the authentication manager builder
+     * @throws Exception if configuration fails
+     */
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
         auth.userDetailsService(tokenService).passwordEncoder(passwordEncoder());
     }
 
+    /**
+     * Provides a {@link BCryptPasswordEncoder} for hashing user passwords and PINs.
+     *
+     * @return the configured {@link PasswordEncoder} bean
+     */
     @Bean
     PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    /**
+     * Exposes the {@link AuthenticationManager} as a Spring bean so it can be
+     * injected into service classes that need to authenticate programmatically.
+     *
+     * @param authenticationConfiguration the auto-configured authentication configuration
+     * @return the application's {@link AuthenticationManager}
+     * @throws Exception if the manager cannot be obtained
+     */
     @Bean
     AuthenticationManager authenticationManager(
             AuthenticationConfiguration authenticationConfiguration)
@@ -65,6 +100,15 @@ public class WebSecurityConfig {
         return authenticationConfiguration.getAuthenticationManager();
     }
 
+    /**
+     * Configures the HTTP security filter chain: disables CSRF, defines public vs
+     * authenticated URL patterns, sets up the JWT entry point and filter, and
+     * enforces stateless session management.
+     *
+     * @param http the {@link HttpSecurity} builder
+     * @return the built {@link SecurityFilterChain}
+     * @throws Exception if configuration fails
+     */
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())

--- a/src/main/java/com/webapp/bankingportal/controller/AccountController.java
+++ b/src/main/java/com/webapp/bankingportal/controller/AccountController.java
@@ -17,6 +17,18 @@ import com.webapp.bankingportal.util.LoggedinUser;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
+/**
+ * REST controller exposing account-level operations for the authenticated user.
+ *
+ * <p>All endpoints in this controller require a valid JWT in the Authorization header.
+ * The account number is always derived from the authentication context via
+ * {@link com.webapp.bankingportal.util.LoggedinUser#getAccountNumber()}; the client
+ * does not need to supply it in the request body.</p>
+ *
+ * <p>State-changing endpoints (deposit, withdraw, fund-transfer, PIN create/update)
+ * are guarded by an idempotency cache so that duplicate requests within the TTL window
+ * are safely deduplicated.</p>
+ */
 @RestController
 @RequestMapping("/api/account")
 @RequiredArgsConstructor
@@ -25,6 +37,11 @@ public class AccountController {
     private final AccountService accountService;
     private final TransactionService transactionService;
 
+    /**
+     * Checks whether a transaction PIN has been set for the authenticated user's account.
+     *
+     * @return {@code 200 OK} with a message indicating whether the PIN exists
+     */
     @GetMapping("/pin/check")
     public ResponseEntity<String> checkAccountPIN() {
         val isPINValid = accountService.isPinCreated(LoggedinUser.getAccountNumber());
@@ -34,6 +51,12 @@ public class AccountController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * Creates a new transaction PIN for the authenticated user's account.
+     *
+     * @param pinRequest the request containing the desired PIN and the user's login password
+     * @return {@code 200 OK} with a success message
+     */
     @PostMapping("/pin/create")
     @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/pin/create' + ':' + (#pinRequest).hashCode()")
     public ResponseEntity<String> createPIN(@RequestBody PinRequest pinRequest) {
@@ -45,6 +68,12 @@ public class AccountController {
         return ResponseEntity.ok(ApiMessages.PIN_CREATION_SUCCESS.getMessage());
     }
 
+    /**
+     * Updates the transaction PIN for the authenticated user's account.
+     *
+     * @param pinUpdateRequest the request containing the old PIN, the new PIN, and the user's login password
+     * @return {@code 200 OK} with a success message
+     */
     @PostMapping("/pin/update")
     @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/pin/update' + ':' + (#pinUpdateRequest).hashCode()")
     public ResponseEntity<String> updatePIN(@RequestBody PinUpdateRequest pinUpdateRequest) {
@@ -57,6 +86,12 @@ public class AccountController {
         return ResponseEntity.ok(ApiMessages.PIN_UPDATE_SUCCESS.getMessage());
     }
 
+    /**
+     * Deposits cash into the authenticated user's account.
+     *
+     * @param amountRequest the request containing the PIN and the amount to deposit
+     * @return {@code 200 OK} with a success message
+     */
     @PostMapping("/deposit")
     @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/deposit' + ':' + (#amountRequest).hashCode()")
     public ResponseEntity<String> cashDeposit(@RequestBody AmountRequest amountRequest) {
@@ -68,6 +103,12 @@ public class AccountController {
         return ResponseEntity.ok(ApiMessages.CASH_DEPOSIT_SUCCESS.getMessage());
     }
 
+    /**
+     * Withdraws cash from the authenticated user's account.
+     *
+     * @param amountRequest the request containing the PIN and the amount to withdraw
+     * @return {@code 200 OK} with a success message
+     */
     @PostMapping("/withdraw")
     @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/withdraw' + ':' + (#amountRequest).hashCode()")
     public ResponseEntity<String> cashWithdrawal(@RequestBody AmountRequest amountRequest) {
@@ -79,6 +120,12 @@ public class AccountController {
         return ResponseEntity.ok(ApiMessages.CASH_WITHDRAWAL_SUCCESS.getMessage());
     }
 
+    /**
+     * Transfers funds from the authenticated user's account to another account.
+     *
+     * @param fundTransferRequest the request containing the target account number, PIN, and amount
+     * @return {@code 200 OK} with a success message
+     */
     @PostMapping("/fund-transfer")
     @Cacheable(value = "idempotency", key = "T(com.webapp.bankingportal.util.LoggedinUser).getAccountNumber() + ':' + '/api/account/fund-transfer' + ':' + (#fundTransferRequest).hashCode()")
     public ResponseEntity<String> fundTransfer(@RequestBody FundTransferRequest fundTransferRequest) {
@@ -91,12 +138,23 @@ public class AccountController {
         return ResponseEntity.ok(ApiMessages.CASH_TRANSFER_SUCCESS.getMessage());
     }
 
+    /**
+     * Returns the full transaction history for the authenticated user's account,
+     * sorted in reverse chronological order.
+     *
+     * @return {@code 200 OK} with a JSON array of {@link com.webapp.bankingportal.dto.TransactionDTO} objects
+     */
     @GetMapping("/transactions")
     public ResponseEntity<String> getAllTransactionsByAccountNumber() {
         val transactions = transactionService
                 .getAllTransactionsByAccountNumber(LoggedinUser.getAccountNumber());
         return ResponseEntity.ok(JsonUtil.toJson(transactions));
     }
+    /**
+     * Emails a plain-text bank statement to the authenticated user's registered email address.
+     *
+     * @return {@code 200 OK} with a JSON confirmation message
+     */
     @GetMapping("/send-statement")
     public ResponseEntity<String> sendBankStatement() {
         String accountNumber = LoggedinUser.getAccountNumber(); // Get logged-in user account

--- a/src/main/java/com/webapp/bankingportal/controller/AuthController.java
+++ b/src/main/java/com/webapp/bankingportal/controller/AuthController.java
@@ -10,6 +10,13 @@ import com.webapp.bankingportal.service.AuthService;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * REST controller for the OTP-based password-reset flow.
+ *
+ * <p>All endpoints in this controller are publicly accessible (no JWT required).
+ * The three-step flow is: send OTP → verify OTP and receive reset token →
+ * submit new password with the reset token.</p>
+ */
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -17,17 +24,35 @@ public class AuthController {
 
     private final AuthService authService;
 
+    /**
+     * Generates an OTP and sends it to the email address associated with the given identifier.
+     *
+     * @param otpRequest request containing the user identifier (email or account number)
+     * @return {@code 200 OK} on successful OTP dispatch, or {@code 500} on email failure
+     */
     @PostMapping("/password-reset/send-otp")
     public ResponseEntity<String> sendOtpForPasswordReset(@RequestBody OtpRequest otpRequest) {
         return authService.sendOtpForPasswordReset(otpRequest);
     }
 
+    /**
+     * Verifies the OTP and, on success, issues a single-use password-reset token.
+     *
+     * @param otpVerificationRequest request containing the identifier and the submitted OTP
+     * @return {@code 200 OK} with the reset token, or {@code 401} if the OTP is invalid
+     */
     @PostMapping("/password-reset/verify-otp")
     public ResponseEntity<String> verifyOtpAndIssueResetToken(
             @RequestBody OtpVerificationRequest otpVerificationRequest) {
         return authService.verifyOtpAndIssueResetToken(otpVerificationRequest);
     }
 
+    /**
+     * Resets the user's password using the one-time reset token obtained from the previous step.
+     *
+     * @param resetPasswordRequest request containing the identifier, reset token, and new password
+     * @return {@code 200 OK} on success, {@code 401} for an invalid reset token, or {@code 500} on failure
+     */
     @PostMapping("/password-reset")
     public ResponseEntity<String> resetPassword(@RequestBody ResetPasswordRequest resetPasswordRequest) {
         return authService.resetPassword(resetPasswordRequest);

--- a/src/main/java/com/webapp/bankingportal/controller/DashboardController.java
+++ b/src/main/java/com/webapp/bankingportal/controller/DashboardController.java
@@ -13,6 +13,13 @@ import com.webapp.bankingportal.util.LoggedinUser;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
+/**
+ * REST controller providing read-only summary views of the authenticated user
+ * and their associated account.
+ *
+ * <p>All endpoints require a valid JWT. The account number is resolved from
+ * the security context.</p>
+ */
 @RestController
 @RequestMapping("/api/dashboard")
 @RequiredArgsConstructor
@@ -20,6 +27,11 @@ public class DashboardController {
 
     private final DashboardService dashboardService;
 
+    /**
+     * Returns profile and account details for the currently authenticated user.
+     *
+     * @return {@code 200 OK} with a JSON {@link com.webapp.bankingportal.dto.UserResponse UserResponse} body
+     */
     @GetMapping("/user")
     public ResponseEntity<String> getUserDetails() {
         val accountNumber = LoggedinUser.getAccountNumber();
@@ -27,6 +39,11 @@ public class DashboardController {
         return ResponseEntity.ok(JsonUtil.toJson(userResponse));
     }
 
+    /**
+     * Returns account details (balance, type, branch, IFSC) for the authenticated user.
+     *
+     * @return {@code 200 OK} with a JSON {@link com.webapp.bankingportal.dto.AccountResponse AccountResponse} body
+     */
     @GetMapping("/account")
     public ResponseEntity<String> getAccountDetails() {
         val accountNumber = LoggedinUser.getAccountNumber();

--- a/src/main/java/com/webapp/bankingportal/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/webapp/bankingportal/controller/GlobalExceptionHandler.java
@@ -26,6 +26,13 @@ import org.springframework.data.redis.RedisConnectionFailureException;
 import java.util.Map;
 import com.webapp.bankingportal.util.ApiMessages;
 
+/**
+ * Centralized exception handler for the entire application.
+ *
+ * <p>Intercepts exceptions thrown by controllers and service methods and converts
+ * them into appropriate HTTP responses. Each handler method maps one exception type
+ * to a specific HTTP status code and returns the exception message as the response body.</p>
+ */
 @ControllerAdvice
 public class GlobalExceptionHandler {
 

--- a/src/main/java/com/webapp/bankingportal/controller/UserController.java
+++ b/src/main/java/com/webapp/bankingportal/controller/UserController.java
@@ -23,6 +23,13 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * REST controller for user registration, authentication, and profile management.
+ *
+ * <p>Public endpoints (register, login, OTP, logout) do not require a JWT.
+ * The update endpoint requires a valid JWT and uses the authenticated user's
+ * password for additional verification.</p>
+ */
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -32,6 +39,12 @@ public class UserController {
 @Autowired
     private EmailService emailService;
 
+    /**
+     * Registers a new user, creates their bank account, and sends a welcome email.
+     *
+     * @param user the user details to register (validated by Bean Validation)
+     * @return {@code 200 OK} with a {@link com.webapp.bankingportal.dto.UserResponse UserResponse} JSON body
+     */
     @PostMapping("/register")
     public ResponseEntity<String> registerUser(@Valid @RequestBody User user) {
         ResponseEntity<String> response = userService.registerUser(user);
@@ -45,17 +58,38 @@ public class UserController {
         return response;
     }
 
+    /**
+     * Authenticates the user with a password and returns a JWT on success.
+     *
+     * @param loginRequest the login credentials (identifier + password)
+     * @param request      the HTTP request used to extract the client IP for the login notification
+     * @return {@code 200 OK} with a JSON body containing the JWT
+     * @throws InvalidTokenException if token generation or persistence fails
+     */
     @PostMapping("/login")
     public ResponseEntity<String> login(@RequestBody LoginRequest loginRequest, HttpServletRequest request)
             throws InvalidTokenException {
         return userService.login(loginRequest, request);
     }
 
+    /**
+     * Generates an OTP and sends it to the user's registered email address.
+     *
+     * @param otpRequest request containing the user identifier (email or account number)
+     * @return {@code 200 OK} on successful OTP dispatch, or {@code 500} on email failure
+     */
     @PostMapping("/generate-otp")
     public ResponseEntity<String> generateOtp(@RequestBody OtpRequest otpRequest) {
         return userService.generateOtp(otpRequest);
     }
 
+    /**
+     * Validates the OTP and, on success, issues a JWT for the authenticated user.
+     *
+     * @param otpVerificationRequest request containing the identifier and OTP
+     * @return {@code 200 OK} with a JSON body containing the JWT
+     * @throws InvalidTokenException if token generation or persistence fails
+     */
     @PostMapping("/verify-otp")
     public ResponseEntity<String> verifyOtpAndLogin(@RequestBody OtpVerificationRequest otpVerificationRequest)
             throws InvalidTokenException {
@@ -63,11 +97,25 @@ public class UserController {
         return userService.verifyOtpAndLogin(otpVerificationRequest);
     }
 
+    /**
+     * Updates the profile of the currently authenticated user.
+     * The user's current password must be supplied for identity verification.
+     *
+     * @param user the new user details (the {@code password} field is used for verification, not updated)
+     * @return {@code 200 OK} with an updated {@link com.webapp.bankingportal.dto.UserResponse UserResponse} JSON body
+     */
     @PostMapping("/update")
     public ResponseEntity<String> updateUser(@RequestBody User user) {
         return userService.updateUser(user);
     }
 
+    /**
+     * Invalidates the JWT in the Authorization header and redirects to the logout page.
+     *
+     * @param token the full Authorization header value (must start with {@code "Bearer "})
+     * @return a redirect {@link ModelAndView} to {@code /logout}
+     * @throws InvalidTokenException if the token is not found or is invalid
+     */
     @GetMapping("/logout")
     public ModelAndView logout(@RequestHeader("Authorization") String token)
             throws InvalidTokenException {

--- a/src/main/java/com/webapp/bankingportal/dto/AccountResponse.java
+++ b/src/main/java/com/webapp/bankingportal/dto/AccountResponse.java
@@ -6,17 +6,37 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Read-only view of an {@link com.webapp.bankingportal.entity.Account Account} returned by the dashboard and
+ * account endpoints.
+ *
+ * <p>Sensitive fields such as the PIN are intentionally excluded.</p>
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class AccountResponse {
 
+    /** The unique 6-digit account number. */
     private String accountNumber;
+
+    /** Current balance of the account. */
     private double balance;
+
+    /** Type of account (e.g., "Savings"). */
     private String accountType;
+
+    /** Branch name associated with the account. */
     private String branch;
+
+    /** IFSC code of the branch. */
     private String ifscCode;
 
+    /**
+     * Constructs an {@code AccountResponse} from a persisted {@link com.webapp.bankingportal.entity.Account Account} entity.
+     *
+     * @param account the source account entity
+     */
     public AccountResponse(Account account) {
         this.accountNumber = account.getAccountNumber();
         this.balance = account.getBalance();

--- a/src/main/java/com/webapp/bankingportal/dto/AmountRequest.java
+++ b/src/main/java/com/webapp/bankingportal/dto/AmountRequest.java
@@ -1,4 +1,11 @@
 package com.webapp.bankingportal.dto;
 
+/**
+ * Request body for cash deposit and cash withdrawal operations.
+ *
+ * @param accountNumber the account number on which the operation is performed
+ * @param pin           the 4-digit PIN authorizing the transaction
+ * @param amount        the monetary amount to deposit or withdraw (must be a positive multiple of 100, max 100,000)
+ */
 public record AmountRequest(String accountNumber, String pin, double amount) {
 }

--- a/src/main/java/com/webapp/bankingportal/dto/ErrorResponse.java
+++ b/src/main/java/com/webapp/bankingportal/dto/ErrorResponse.java
@@ -1,4 +1,9 @@
 package com.webapp.bankingportal.dto;
 
+/**
+ * Standard error response body returned by the API when a request fails.
+ *
+ * @param message a human-readable description of the error
+ */
 public record ErrorResponse(String message) {
 }

--- a/src/main/java/com/webapp/bankingportal/dto/FundTransferRequest.java
+++ b/src/main/java/com/webapp/bankingportal/dto/FundTransferRequest.java
@@ -1,4 +1,12 @@
 package com.webapp.bankingportal.dto;
 
+/**
+ * Request body for a fund transfer between two accounts.
+ *
+ * @param sourceAccountNumber the account number from which funds are debited
+ * @param targetAccountNumber the account number to which funds are credited
+ * @param amount              the monetary amount to transfer (must be a positive multiple of 100, max 100,000)
+ * @param pin                 the 4-digit PIN of the source account authorizing the transfer
+ */
 public record FundTransferRequest(String sourceAccountNumber, String targetAccountNumber, double amount, String pin) {
 }

--- a/src/main/java/com/webapp/bankingportal/dto/GeolocationResponse.java
+++ b/src/main/java/com/webapp/bankingportal/dto/GeolocationResponse.java
@@ -7,106 +7,157 @@ import lombok.Data;
 import java.util.Map;
 import java.util.List;
 
+/**
+ * Response DTO that maps the JSON payload returned by the external IP
+ * geolocation API.
+ *
+ * <p>Used by {@link com.webapp.bankingportal.service.GeolocationService} to
+ * determine a user's approximate geographic location at login time, which is
+ * then included in the login-notification email.</p>
+ */
 @Data
 public class GeolocationResponse {
 
+    /** City-level information for the resolved IP address. */
     @Data
     public static class City {
 
+        /** GeoNames database identifier for this city. */
         @JsonProperty("geoname_id")
         private int geonameId;
 
+        /** Localised city name strings keyed by ISO 639-1 language code (e.g., {@code "en"}). */
         private Map<String, String> names;
 
     }
 
+    /** Continent-level information for the resolved IP address. */
     @Data
     public static class Continent {
 
+        /** Two-letter continent code (e.g., {@code "NA"} for North America). */
         private String code;
 
+        /** GeoNames database identifier for this continent. */
         @JsonProperty("geoname_id")
         private int geonameId;
 
+        /** Localised continent name strings keyed by ISO 639-1 language code. */
         private Map<String, String> names;
 
     }
 
+    /** Country-level information for the resolved IP address. */
     @Data
     public static class Country {
 
+        /** GeoNames database identifier for this country. */
         @JsonProperty("geoname_id")
         private int geonameId;
 
+        /** Whether the country is a member of the European Union. */
         @JsonProperty("is_in_european_union")
         private boolean isInEuropeanUnion;
 
+        /** ISO 3166-1 alpha-2 country code (e.g., {@code "US"}). */
         @JsonProperty("iso_code")
         private String isoCode;
 
+        /** Localised country name strings keyed by ISO 639-1 language code. */
         private Map<String, String> names;
 
     }
 
+    /** Geographic coordinates and timezone for the resolved IP address. */
     @Data
     public static class Location {
 
+        /** Latitude of the estimated location. */
         private double latitude;
+
+        /** Longitude of the estimated location. */
         private double longitude;
 
+        /** IANA timezone identifier (e.g., {@code "America/New_York"}). */
         @JsonProperty("time_zone")
         private String timeZone;
 
+        /** Weather code for the estimated location, if provided by the API. */
         @JsonProperty("weather_code")
         private String weatherCode;
 
     }
 
+    /** Postal code information for the resolved IP address. */
     @Data
     public static class Postal {
 
+        /** Postal/ZIP code string for the estimated location. */
         private String code;
 
     }
 
+    /** Administrative subdivision (state/province) information. */
     @Data
     public static class Subdivision {
 
+        /** GeoNames database identifier for this subdivision. */
         @JsonProperty("geoname_id")
         private int geonameId;
 
+        /** ISO 3166-2 subdivision code. */
         @JsonProperty("iso_code")
         private String isoCode;
 
+        /** Localised subdivision name strings keyed by ISO 639-1 language code. */
         private Map<String, String> names;
 
     }
 
+    /** ISP and network traits for the resolved IP address. */
     @Data
     public static class Traits {
 
+        /** Autonomous System Number (ASN) for the IP. */
         @JsonProperty("autonomous_system_number")
         private int autonomousSystemNumber;
 
+        /** Organization that owns the Autonomous System. */
         @JsonProperty("autonomous_system_organization")
         private String autonomousSystemOrganization;
 
+        /** Connection type (e.g., {@code "Corporate"}, {@code "Residential"}). */
         @JsonProperty("connection_type")
         private String connectionType;
 
+        /** Internet Service Provider name. */
         private String isp;
 
+        /** Classification of the IP user type (e.g., {@code "business"}). */
         @JsonProperty("user_type")
         private String userType;
 
     }
 
+    /** City-level information. */
     private City city;
+
+    /** Continent-level information. */
     private Continent continent;
+
+    /** Country-level information. */
     private Country country;
+
+    /** Geographic coordinates and timezone. */
     private Location location;
+
+    /** Postal code information. */
     private Postal postal;
+
+    /** List of administrative subdivisions (e.g., states/provinces). */
     private List<Subdivision> subdivisions;
+
+    /** ISP and network trait information. */
     private Traits traits;
 
 }

--- a/src/main/java/com/webapp/bankingportal/dto/LoginRequest.java
+++ b/src/main/java/com/webapp/bankingportal/dto/LoginRequest.java
@@ -1,4 +1,10 @@
 package com.webapp.bankingportal.dto;
 
+/**
+ * Request body for standard password-based login.
+ *
+ * @param identifier either the user's email address or 6-digit account number
+ * @param password   the plain-text password to authenticate with
+ */
 public record LoginRequest(String identifier, String password) {
 }

--- a/src/main/java/com/webapp/bankingportal/dto/OtpRequest.java
+++ b/src/main/java/com/webapp/bankingportal/dto/OtpRequest.java
@@ -1,4 +1,10 @@
 package com.webapp.bankingportal.dto;
 
+/**
+ * Request body for generating and sending an OTP to a user.
+ *
+ * @param identifier either the user's email address or 6-digit account number
+ *                   used to look up the target account
+ */
 public record OtpRequest(String identifier) {
 }

--- a/src/main/java/com/webapp/bankingportal/dto/OtpVerificationRequest.java
+++ b/src/main/java/com/webapp/bankingportal/dto/OtpVerificationRequest.java
@@ -1,4 +1,10 @@
 package com.webapp.bankingportal.dto;
 
+/**
+ * Request body for verifying an OTP submitted by a user.
+ *
+ * @param identifier either the user's email address or 6-digit account number
+ * @param otp        the 6-digit OTP value previously sent to the user's email
+ */
 public record OtpVerificationRequest(String identifier, String otp) {
 }

--- a/src/main/java/com/webapp/bankingportal/dto/PinRequest.java
+++ b/src/main/java/com/webapp/bankingportal/dto/PinRequest.java
@@ -1,4 +1,11 @@
 package com.webapp.bankingportal.dto;
 
+/**
+ * Request body for creating a new transaction PIN on an account.
+ *
+ * @param accountNumber the account number for which the PIN is being created
+ * @param pin           the desired 4-digit numeric PIN
+ * @param password      the account holder's login password, used to verify identity before PIN creation
+ */
 public record PinRequest(String accountNumber, String pin, String password) {
 }

--- a/src/main/java/com/webapp/bankingportal/dto/PinUpdateRequest.java
+++ b/src/main/java/com/webapp/bankingportal/dto/PinUpdateRequest.java
@@ -1,4 +1,12 @@
 package com.webapp.bankingportal.dto;
 
+/**
+ * Request body for updating an existing transaction PIN on an account.
+ *
+ * @param accountNumber the account number whose PIN is being updated
+ * @param oldPin        the current 4-digit PIN to verify ownership
+ * @param newPin        the new 4-digit numeric PIN to set
+ * @param password      the account holder's login password for additional identity verification
+ */
 public record PinUpdateRequest(String accountNumber, String oldPin, String newPin, String password) {
 }

--- a/src/main/java/com/webapp/bankingportal/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/webapp/bankingportal/dto/ResetPasswordRequest.java
@@ -1,4 +1,11 @@
 package com.webapp.bankingportal.dto;
 
+/**
+ * Request body for completing a password reset.
+ *
+ * @param identifier  either the user's email address or 6-digit account number
+ * @param resetToken  the single-use UUID token issued after successful OTP verification
+ * @param newPassword the desired new password (must meet the password complexity requirements)
+ */
 public record ResetPasswordRequest(String identifier, String resetToken, String newPassword) {
 }

--- a/src/main/java/com/webapp/bankingportal/dto/TransactionDTO.java
+++ b/src/main/java/com/webapp/bankingportal/dto/TransactionDTO.java
@@ -10,18 +10,44 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.val;
 
+/**
+ * Data transfer object representing a single transaction in the transaction history.
+ *
+ * <p>Returned by the transaction list endpoint. Account entity references are
+ * replaced by their string account numbers to avoid exposing sensitive data.</p>
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class TransactionDTO {
 
+    /** Unique identifier of the transaction. */
     private Long id;
+
+    /** Monetary amount involved in the transaction. */
     private double amount;
+
+    /** Category of the transaction (deposit, withdrawal, transfer, credit). */
     private TransactionType transactionType;
+
+    /** Timestamp when the transaction was recorded. */
     private Date transactionDate;
+
+    /** Account number of the originating account. */
     private String sourceAccountNumber;
+
+    /**
+     * Account number of the receiving account, or {@code "N/A"} for
+     * unilateral operations such as deposits and withdrawals.
+     */
     private String targetAccountNumber;
 
+    /**
+     * Constructs a {@code TransactionDTO} from a {@link Transaction} entity,
+     * extracting account numbers from the associated account objects.
+     *
+     * @param transaction the source transaction entity
+     */
     public TransactionDTO(Transaction transaction) {
         this.id = transaction.getId();
         this.amount = transaction.getAmount();

--- a/src/main/java/com/webapp/bankingportal/dto/UserResponse.java
+++ b/src/main/java/com/webapp/bankingportal/dto/UserResponse.java
@@ -5,20 +5,48 @@ import com.webapp.bankingportal.entity.User;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Read-only projection of a {@link com.webapp.bankingportal.entity.User User} and their associated account,
+ * returned by registration, update, and dashboard endpoints.
+ *
+ * <p>Sensitive fields such as the password and PIN are intentionally excluded.</p>
+ */
 @NoArgsConstructor
 @Data
 public class UserResponse {
 
+    /** Full name of the user. */
     private String name;
+
+    /** Email address of the user. */
     private String email;
+
+    /** ISO 3166-1 alpha-2 country code (e.g., "US"). */
     private String countryCode;
+
+    /** Phone number of the user. */
     private String phoneNumber;
+
+    /** Residential address of the user. */
     private String address;
+
+    /** The unique 6-digit account number linked to this user. */
     private String accountNumber;
+
+    /** IFSC code of the account's branch. */
     private String ifscCode;
+
+    /** Branch name of the account. */
     private String branch;
+
+    /** Account type (e.g., "Savings"). */
     private String accountType;
 
+    /**
+     * Constructs a {@code UserResponse} by projecting fields from a {@link com.webapp.bankingportal.entity.User User} entity.
+     *
+     * @param user the source user entity (must have a non-null associated account)
+     */
     public UserResponse(User user) {
         this.name = user.getName();
         this.email = user.getEmail();

--- a/src/main/java/com/webapp/bankingportal/entity/Account.java
+++ b/src/main/java/com/webapp/bankingportal/entity/Account.java
@@ -16,32 +16,54 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+/**
+ * JPA entity representing a bank account in the system.
+ *
+ * <p>Each account is linked one-to-one with a {@link User} and holds the
+ * account balance, type, branch details, and the hashed PIN used to
+ * authorize transactions. A single account may have many associated
+ * {@link Token} records (JWT tokens issued during active sessions).</p>
+ */
 @Entity
 @Data
 public class Account {
 
+    /** Auto-generated primary key. */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /** Unique 6-digit account number assigned on account creation. */
     @NotEmpty
     @Column(unique = true)
     private String accountNumber;
 
+    /** Type of account (e.g., "Savings"). Defaults to {@code "Savings"}. */
     @NotEmpty
     private String accountType = "Savings";
 
+    /** Current status of the account (e.g., active, suspended). */
     private String accountStatus;
+
+    /** Current account balance. */
     private double balance;
+
+    /** Branch name associated with this account. Defaults to {@code "NIT"}. */
     private String branch = "NIT";
+
+    /** IFSC code of the branch. Defaults to {@code "NIT001"}. */
     private String ifscCode = "NIT001";
+
+    /** BCrypt-hashed 4-digit PIN used to authorize transactions. */
     private String Pin;
 
+    /** The user who owns this account. */
     @NotNull
     @OneToOne
     @JoinColumn(name = "user_id")
     private User user;
 
+    /** JWT tokens issued to the account's user across active sessions. */
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL)
     private List<Token> tokens = new ArrayList<>();
 

--- a/src/main/java/com/webapp/bankingportal/entity/OtpInfo.java
+++ b/src/main/java/com/webapp/bankingportal/entity/OtpInfo.java
@@ -11,24 +11,43 @@ import jakarta.persistence.Id;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * JPA entity that stores an active one-time password (OTP) for an account.
+ *
+ * <p>Only one OTP record exists per account number at any given time.
+ * The record is deleted once the OTP is consumed or expires. The
+ * {@code generatedAt} field is used both to determine expiry and to track
+ * the retry-limit window.</p>
+ */
 @Entity
 @NoArgsConstructor
 @Data
 public class OtpInfo {
 
+    /** Auto-generated primary key. */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /** Account number for which this OTP was generated. Unique per account. */
     @Column(unique = true)
     private String accountNumber;
 
+    /** The 6-digit OTP value (stored as plain text for fast lookup). */
     @Column
     private String otp;
 
+    /** Timestamp when the OTP was generated or last refreshed. */
     @Column
     private LocalDateTime generatedAt;
 
+    /**
+     * Creates a new OtpInfo record.
+     *
+     * @param accountNumber the account number the OTP belongs to
+     * @param otp           the generated OTP value
+     * @param generatedAt   the timestamp at which the OTP was created
+     */
     public OtpInfo(String accountNumber, String otp, LocalDateTime generatedAt) {
         this.accountNumber = accountNumber;
         this.otp = otp;

--- a/src/main/java/com/webapp/bankingportal/entity/PasswordResetToken.java
+++ b/src/main/java/com/webapp/bankingportal/entity/PasswordResetToken.java
@@ -17,32 +17,57 @@ import lombok.NoArgsConstructor;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
+/**
+ * JPA entity representing a single-use token used to authorize a password reset.
+ *
+ * <p>Tokens are issued after OTP verification and are valid for
+ * {@code AuthServiceImpl#EXPIRATION_HOURS} hours. Once used they are deleted.
+ * Implements {@link Serializable} to support sequence-generator strategies
+ * across JPA providers.</p>
+ */
 @Entity
 @Table(name = "passwordresettoken")
 @Data
 @NoArgsConstructor
 public class PasswordResetToken implements Serializable {
+
+    /** Auto-generated primary key using a database sequence. */
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "passwordresettoken_sequence")
     @SequenceGenerator(name = "passwordresettoken_sequence", sequenceName = "passwordresettoken_sequence", allocationSize = 100)
     private Long id;
 
+    /** Opaque UUID token string sent to the user for password reset. */
     @Column(nullable = false, unique = true)
     private String token;
 
+    /** The user who requested the password reset. */
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    /** Timestamp after which this token is considered expired. */
     @Column(nullable = false)
     private LocalDateTime expiryDateTime;
 
+    /**
+     * Creates a new PasswordResetToken.
+     *
+     * @param token          the opaque UUID reset token string
+     * @param user           the user requesting the password reset
+     * @param expiryDateTime the point in time at which the token expires
+     */
     public PasswordResetToken(String token, User user, LocalDateTime expiryDateTime) {
         this.token = token;
         this.user = user;
         this.expiryDateTime = expiryDateTime;
     }
 
+    /**
+     * Returns {@code true} if the token has not yet passed its expiry date/time.
+     *
+     * @return {@code true} if the token is still valid, {@code false} otherwise
+     */
     public boolean isTokenValid() {
         return getExpiryDateTime().isAfter(LocalDateTime.now());
     }

--- a/src/main/java/com/webapp/bankingportal/entity/Token.java
+++ b/src/main/java/com/webapp/bankingportal/entity/Token.java
@@ -15,30 +15,49 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * JPA entity representing a JWT session token issued to an account.
+ *
+ * <p>Tokens are persisted when a user logs in and are removed (invalidated)
+ * on logout or expiry. Storing tokens in the database allows the application
+ * to perform server-side revocation of JWTs.</p>
+ */
 @Entity
 @NoArgsConstructor
 @Data
 public class Token {
 
+    /** Auto-generated primary key. */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /** Raw JWT string. Must be unique across all active tokens. */
     @NotEmpty
     @Column(unique = true)
     private String token;
 
+    /** Timestamp when this token was issued. Defaults to the current time. */
     @NotNull
     private Date createdAt = new Date();
 
+    /** Timestamp after which the token is considered expired. */
     @NotNull
     private Date expiryAt;
 
+    /** The account to which this token belongs. */
     @NotNull
     @ManyToOne
     @JoinColumn(name = "account_id")
     private Account account;
 
+    /**
+     * Creates a new Token with the given JWT string, expiry time, and associated account.
+     *
+     * @param token    the raw JWT string
+     * @param expiryAt the expiry timestamp of the token
+     * @param account  the account this token is associated with
+     */
     public Token(String token, Date expiryAt, Account account) {
         this.token = token;
         this.expiryAt = expiryAt;

--- a/src/main/java/com/webapp/bankingportal/entity/Transaction.java
+++ b/src/main/java/com/webapp/bankingportal/entity/Transaction.java
@@ -13,23 +13,41 @@ import jakarta.persistence.ManyToOne;
 
 import lombok.Data;
 
+/**
+ * JPA entity that records a single financial transaction.
+ *
+ * <p>Transactions are created automatically by the account service during
+ * deposits, withdrawals, and fund transfers. For unilateral operations
+ * (deposit/withdrawal) only {@code sourceAccount} is populated; for
+ * transfers both {@code sourceAccount} and {@code targetAccount} are set.</p>
+ *
+ * @see TransactionType
+ */
 @Entity
 @Data
 public class Transaction {
+
+    /** Auto-generated primary key. */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    /** Monetary amount involved in the transaction. */
     private double amount;
 
+    /** Category of the transaction (deposit, withdrawal, transfer, credit). */
     @Enumerated(EnumType.STRING)
     private TransactionType transactionType;
 
+    /** Timestamp at which the transaction was recorded. */
     private Date transactionDate;
 
+    /** Account from which funds originated (always set). */
     @ManyToOne
     @JoinColumn(name = "source_account_id")
     private Account sourceAccount;
 
+    /** Destination account for fund transfers; {@code null} for unilateral operations. */
     @ManyToOne
     @JoinColumn(name = "target_account_id")
     private Account targetAccount;

--- a/src/main/java/com/webapp/bankingportal/entity/TransactionType.java
+++ b/src/main/java/com/webapp/bankingportal/entity/TransactionType.java
@@ -1,8 +1,17 @@
 package com.webapp.bankingportal.entity;
 
+/**
+ * Enumeration of the transaction types supported by the banking portal.
+ *
+ * <p>This value is persisted as a string column in the {@code transaction} table.</p>
+ */
 public enum TransactionType {
+    /** Funds removed from an account by the account holder. */
     CASH_WITHDRAWAL,
+    /** Funds added to an account by the account holder. */
     CASH_DEPOSIT,
+    /** Funds moved from one account to another. */
     CASH_TRANSFER,
+    /** Credit applied to an account (e.g., interest or refund). */
     CASH_CREDIT
 }

--- a/src/main/java/com/webapp/bankingportal/entity/User.java
+++ b/src/main/java/com/webapp/bankingportal/entity/User.java
@@ -18,35 +18,51 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * JPA entity representing a registered user of the banking portal.
+ *
+ * <p>A user holds personal contact information and is associated with exactly
+ * one {@link Account} through a bidirectional one-to-one relationship.
+ * Passwords are stored in BCrypt-hashed form; plain-text passwords must never
+ * be persisted.</p>
+ */
 @Entity
 @Data
 public class User {
+
+    /** Auto-generated primary key. */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /** Full name of the user. */
     @NotEmpty
     private String name;
 
+    /** BCrypt-hashed password. Never stored in plain text. */
     @NotEmpty
     private String password;
 
+    /** Unique email address used for login and notifications. */
     @Email
-   @NotEmpty
+    @NotEmpty
     @Column(unique = true)
     private String email;
 
+    /** ISO 3166-1 alpha-2 country code (e.g., "US", "IN"). Stored in uppercase. */
     @NotEmpty
     private String countryCode;
 
+    /** Unique phone number including the national subscriber number. */
     @NotEmpty
     @Column(unique = true)
     private String phoneNumber;
 
+    /** Residential or mailing address of the user. */
     @NotEmpty
     private String address;
 
-    // Establishing a one-to-one relationship with the account
+    /** The bank account associated with this user (created on registration). */
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     private Account account;
 

--- a/src/main/java/com/webapp/bankingportal/exception/AccountDoesNotExistException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/AccountDoesNotExistException.java
@@ -1,7 +1,17 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when an operation references an account number that does not exist in the database.
+ *
+ * <p>Mapped to HTTP 400 Bad Request by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class AccountDoesNotExistException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public AccountDoesNotExistException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/FundTransferException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/FundTransferException.java
@@ -1,7 +1,18 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when a fund-transfer operation cannot be completed due to a business rule violation
+ * (e.g., the source and target accounts are the same).
+ *
+ * <p>Mapped to HTTP 400 Bad Request by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class FundTransferException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public FundTransferException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/GeolocationException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/GeolocationException.java
@@ -1,7 +1,17 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when the external geolocation API call fails or returns an unusable response.
+ *
+ * <p>Mapped to HTTP 400 Bad Request by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class GeolocationException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public GeolocationException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/InsufficientBalanceException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/InsufficientBalanceException.java
@@ -1,7 +1,17 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when a withdrawal or transfer is requested for an amount that exceeds the account balance.
+ *
+ * <p>Mapped to HTTP 400 Bad Request by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class InsufficientBalanceException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public InsufficientBalanceException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/InvalidAmountException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/InvalidAmountException.java
@@ -1,7 +1,18 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when a transaction amount violates a business rule (e.g., negative, not a multiple of
+ * 100, or exceeds the maximum limit).
+ *
+ * <p>Mapped to HTTP 400 Bad Request by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class InvalidAmountException extends RuntimeException {
-    
+
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public InvalidAmountException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/InvalidOtpException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/InvalidOtpException.java
@@ -1,7 +1,17 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when an OTP submitted by the user does not match the stored value or is not found.
+ *
+ * <p>Mapped to HTTP 401 Unauthorized by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class InvalidOtpException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param msg the detail message
+     */
     public InvalidOtpException(String msg) {
         super(msg);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/InvalidPinException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/InvalidPinException.java
@@ -1,7 +1,17 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when a PIN fails format validation (e.g., not 4 digits) during creation or update.
+ *
+ * <p>Mapped to HTTP 400 Bad Request by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class InvalidPinException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public InvalidPinException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/InvalidTokenException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/InvalidTokenException.java
@@ -1,7 +1,20 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Checked exception thrown when a JWT is expired, malformed, has an invalid signature,
+ * is not found in the database, or is otherwise unusable.
+ *
+ * <p>Mapped to HTTP 401 Unauthorized by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.
+ * Declared as a checked exception ({@link Exception}) rather than a runtime exception
+ * because callers must explicitly decide how to handle an invalid token.</p>
+ */
 public class InvalidTokenException extends Exception {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public InvalidTokenException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/NotFoundException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/NotFoundException.java
@@ -1,7 +1,17 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when a requested resource (user, account, etc.) cannot be found in the database.
+ *
+ * <p>Mapped to HTTP 404 Not Found by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class NotFoundException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public NotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/OtpRetryLimitExceededException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/OtpRetryLimitExceededException.java
@@ -1,7 +1,19 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when a user has requested too many OTPs within the allowed retry window and must wait
+ * before requesting another.
+ *
+ * <p>Mapped to HTTP 400 Bad Request by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.
+ * The message typically includes the number of minutes remaining before the user can try again.</p>
+ */
 public class OtpRetryLimitExceededException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message including the wait time.
+     *
+     * @param message the detail message (e.g., "OTP generation limit exceeded. Please try again after 8 minutes")
+     */
     public OtpRetryLimitExceededException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/PasswordResetException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/PasswordResetException.java
@@ -1,10 +1,28 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when a password-reset operation fails due to a persistence or unexpected error.
+ *
+ * <p>Mapped to HTTP 500 Internal Server Error by
+ * {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class PasswordResetException extends RuntimeException {
+
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public PasswordResetException(String message) {
         super(message);
     }
 
+    /**
+     * Constructs the exception with a descriptive message and the underlying cause.
+     *
+     * @param message the detail message
+     * @param cause   the exception that triggered this failure
+     */
     public PasswordResetException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/UnauthorizedException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/UnauthorizedException.java
@@ -1,7 +1,18 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when an authenticated user attempts an operation they are not authorized to perform
+ * (e.g., wrong PIN, wrong password, no PIN set).
+ *
+ * <p>Mapped to HTTP 401 Unauthorized by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class UnauthorizedException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public UnauthorizedException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/exception/UserInvalidException.java
+++ b/src/main/java/com/webapp/bankingportal/exception/UserInvalidException.java
@@ -1,7 +1,18 @@
 package com.webapp.bankingportal.exception;
 
+/**
+ * Thrown when user-supplied registration or profile data fails validation
+ * (e.g., invalid email format, duplicate phone number, weak password).
+ *
+ * <p>Mapped to HTTP 400 Bad Request by {@link com.webapp.bankingportal.controller.GlobalExceptionHandler}.</p>
+ */
 public class UserInvalidException extends RuntimeException {
 
+    /**
+     * Constructs the exception with a descriptive message.
+     *
+     * @param message the detail message
+     */
     public UserInvalidException(String message) {
         super(message);
     }

--- a/src/main/java/com/webapp/bankingportal/mapper/TransactionMapper.java
+++ b/src/main/java/com/webapp/bankingportal/mapper/TransactionMapper.java
@@ -5,9 +5,19 @@ import org.springframework.stereotype.Component;
 import com.webapp.bankingportal.dto.TransactionDTO;
 import com.webapp.bankingportal.entity.Transaction;
 
+/**
+ * Mapper component that converts {@link Transaction} entities into
+ * {@link TransactionDTO} data transfer objects.
+ */
 @Component
 public class TransactionMapper {
 
+    /**
+     * Converts a {@link Transaction} entity to a {@link TransactionDTO}.
+     *
+     * @param transaction the source transaction entity
+     * @return a {@link TransactionDTO} populated from the given entity
+     */
     public TransactionDTO toDto(Transaction transaction) {
         return new TransactionDTO(transaction);
     }

--- a/src/main/java/com/webapp/bankingportal/mapper/UserMapper.java
+++ b/src/main/java/com/webapp/bankingportal/mapper/UserMapper.java
@@ -7,9 +7,23 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 
 import com.webapp.bankingportal.entity.User;
 
+/**
+ * MapStruct mapper for updating {@link com.webapp.bankingportal.entity.User User} entities.
+ *
+ * <p>Registered as a Spring bean ({@code componentModel = "spring"}) so it can be
+ * dependency-injected into service classes.</p>
+ */
 @Mapper(componentModel = "spring")
 public interface UserMapper {
 
+    /**
+     * Copies non-null properties from {@code source} onto {@code target}, leaving
+     * existing values in {@code target} intact when the corresponding field in
+     * {@code source} is {@code null}.
+     *
+     * @param source the user object carrying the updated field values
+     * @param target the existing user entity to be updated in place
+     */
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-    public void updateUser(User source, @MappingTarget User target);
+    void updateUser(User source, @MappingTarget User target);
 }

--- a/src/main/java/com/webapp/bankingportal/repository/AccountRepository.java
+++ b/src/main/java/com/webapp/bankingportal/repository/AccountRepository.java
@@ -5,8 +5,17 @@ import org.springframework.stereotype.Repository;
 
 import com.webapp.bankingportal.entity.Account;
 
+/**
+ * Spring Data JPA repository for {@link Account} entities.
+ */
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
+    /**
+     * Finds an account by its unique account number.
+     *
+     * @param accountNumber the 6-character account number to search for
+     * @return the matching {@link Account}, or {@code null} if not found
+     */
     Account findByAccountNumber(String accountNumber);
 }

--- a/src/main/java/com/webapp/bankingportal/repository/OtpInfoRepository.java
+++ b/src/main/java/com/webapp/bankingportal/repository/OtpInfoRepository.java
@@ -5,10 +5,27 @@ import org.springframework.stereotype.Repository;
 
 import com.webapp.bankingportal.entity.OtpInfo;
 
+/**
+ * Spring Data JPA repository for {@link OtpInfo} entities.
+ */
 @Repository
 public interface OtpInfoRepository extends JpaRepository<OtpInfo, Long> {
 
+    /**
+     * Finds an OTP record matching both the account number and the OTP value.
+     * Used during OTP validation.
+     *
+     * @param accountNumber the account number the OTP belongs to
+     * @param otp           the OTP value to match
+     * @return the matching {@link OtpInfo}, or {@code null} if not found
+     */
     OtpInfo findByAccountNumberAndOtp(String accountNumber, String otp);
 
+    /**
+     * Finds the active OTP record for a given account number.
+     *
+     * @param accountNumber the account number to look up
+     * @return the active {@link OtpInfo} record, or {@code null} if none exists
+     */
     OtpInfo findByAccountNumber(String accountNumber);
 }

--- a/src/main/java/com/webapp/bankingportal/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/webapp/bankingportal/repository/PasswordResetTokenRepository.java
@@ -8,11 +8,32 @@ import org.springframework.stereotype.Repository;
 import com.webapp.bankingportal.entity.PasswordResetToken;
 import com.webapp.bankingportal.entity.User;
 
+/**
+ * Spring Data JPA repository for {@link PasswordResetToken} entities.
+ */
 @Repository
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+
+    /**
+     * Finds a password-reset token record by its UUID string value.
+     *
+     * @param token the token string to search for
+     * @return an {@link Optional} containing the token record, or empty if not found
+     */
     Optional<PasswordResetToken> findByToken(String token);
 
+    /**
+     * Finds the password-reset token currently associated with a given user.
+     *
+     * @param user the user whose reset token is requested
+     * @return the active {@link PasswordResetToken} for the user, or {@code null} if none exists
+     */
     PasswordResetToken findByUser(User user);
 
+    /**
+     * Deletes the password-reset token record identified by the given string.
+     *
+     * @param token the token string identifying the record to delete
+     */
     void deleteByToken(String token);
 }

--- a/src/main/java/com/webapp/bankingportal/repository/TokenRepository.java
+++ b/src/main/java/com/webapp/bankingportal/repository/TokenRepository.java
@@ -6,12 +6,32 @@ import org.springframework.stereotype.Repository;
 import com.webapp.bankingportal.entity.Account;
 import com.webapp.bankingportal.entity.Token;
 
+/**
+ * Spring Data JPA repository for JWT {@link Token} entities.
+ */
 @Repository
 public interface TokenRepository extends JpaRepository<Token, Long> {
 
+    /**
+     * Finds a persisted token record by its JWT string value.
+     *
+     * @param token the raw JWT string
+     * @return the matching {@link Token}, or {@code null} if not found
+     */
     Token findByToken(String token);
 
+    /**
+     * Returns all tokens associated with a given account.
+     *
+     * @param account the account whose tokens are to be retrieved
+     * @return an array of {@link Token} records (may be empty)
+     */
     Token[] findAllByAccount(Account account);
 
+    /**
+     * Deletes the token record with the given JWT string.
+     *
+     * @param token the raw JWT string identifying the record to delete
+     */
     void deleteByToken(String token);
 }

--- a/src/main/java/com/webapp/bankingportal/repository/TransactionRepository.java
+++ b/src/main/java/com/webapp/bankingportal/repository/TransactionRepository.java
@@ -7,9 +7,22 @@ import org.springframework.stereotype.Repository;
 
 import com.webapp.bankingportal.entity.Transaction;
 
+/**
+ * Spring Data JPA repository for {@link Transaction} entities.
+ */
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
-    // Add any custom query methods here, if needed
-	
-    List<Transaction> findBySourceAccount_AccountNumberOrTargetAccount_AccountNumber(String sourceAccountNumber, String targetAccountNumber);
+
+    /**
+     * Returns all transactions in which the given account number appears as either
+     * the source or the target account.
+     *
+     * @param sourceAccountNumber the account number to match against the source account
+     * @param targetAccountNumber the account number to match against the target account
+     *                            (pass the same value as {@code sourceAccountNumber} to retrieve
+     *                            all transactions for a single account)
+     * @return a list of matching {@link Transaction} records, possibly empty
+     */
+    List<Transaction> findBySourceAccount_AccountNumberOrTargetAccount_AccountNumber(
+            String sourceAccountNumber, String targetAccountNumber);
 }

--- a/src/main/java/com/webapp/bankingportal/repository/UserRepository.java
+++ b/src/main/java/com/webapp/bankingportal/repository/UserRepository.java
@@ -7,12 +7,33 @@ import org.springframework.stereotype.Repository;
 
 import com.webapp.bankingportal.entity.User;
 
+/**
+ * Spring Data JPA repository for {@link User} entities.
+ */
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    /**
+     * Finds a user by their unique email address.
+     *
+     * @param email the email address to search for
+     * @return an {@link Optional} containing the user, or empty if not found
+     */
     Optional<User> findByEmail(String email);
 
+    /**
+     * Finds a user by their unique phone number.
+     *
+     * @param phoneNumber the phone number to search for
+     * @return an {@link Optional} containing the user, or empty if not found
+     */
     Optional<User> findByPhoneNumber(String phoneNumber);
 
+    /**
+     * Finds a user by the account number of their associated bank account.
+     *
+     * @param accountNumber the 6-character account number to search for
+     * @return an {@link Optional} containing the user, or empty if not found
+     */
     Optional<User> findByAccountAccountNumber(String accountNumber);
 }

--- a/src/main/java/com/webapp/bankingportal/service/AccountService.java
+++ b/src/main/java/com/webapp/bankingportal/service/AccountService.java
@@ -3,15 +3,92 @@ package com.webapp.bankingportal.service;
 import com.webapp.bankingportal.entity.Account;
 import com.webapp.bankingportal.entity.User;
 
+/**
+ * Service contract for account management and financial transaction operations.
+ *
+ * <p>Provides operations for account creation, PIN management, and fund
+ * movements (deposit, withdrawal, transfer). All methods that require user
+ * authorization validate the provided PIN before executing.</p>
+ */
 public interface AccountService {
 
-	public Account createAccount(User user);
-	public boolean isPinCreated(String accountNumber) ;
-	public void createPin(String accountNumber, String password, String pin) ;
-	public void updatePin(String accountNumber, String oldPIN, String password, String newPIN);
-	public void cashDeposit(String accountNumber, String pin, double amount);
-	public void cashWithdrawal(String accountNumber, String pin, double amount);
-	public void fundTransfer(String sourceAccountNumber, String targetAccountNumber, String pin, double amount);
-	
-	
+    /**
+     * Creates a new bank account for the given user with a zero balance.
+     *
+     * @param user the user for whom the account is being created
+     * @return the newly created and persisted {@link Account}
+     */
+    Account createAccount(User user);
+
+    /**
+     * Checks whether a transaction PIN has been created for the given account.
+     *
+     * @param accountNumber the account number to check
+     * @return {@code true} if a PIN exists, {@code false} otherwise
+     * @throws com.webapp.bankingportal.exception.NotFoundException if no account matches {@code accountNumber}
+     */
+    boolean isPinCreated(String accountNumber);
+
+    /**
+     * Creates a new 4-digit transaction PIN for an account after verifying the
+     * account holder's password.
+     *
+     * @param accountNumber the account number on which to create the PIN
+     * @param password      the account holder's login password for identity verification
+     * @param pin           the 4-digit numeric PIN to set
+     * @throws com.webapp.bankingportal.exception.UnauthorizedException if the password is incorrect or a PIN already exists
+     * @throws com.webapp.bankingportal.exception.InvalidPinException   if the PIN format is invalid
+     */
+    void createPin(String accountNumber, String password, String pin);
+
+    /**
+     * Updates the transaction PIN on an account after verifying both the old PIN and
+     * the account holder's password.
+     *
+     * @param accountNumber the account number whose PIN is being updated
+     * @param oldPIN        the current PIN to verify
+     * @param password      the account holder's login password for additional verification
+     * @param newPIN        the new 4-digit numeric PIN to set
+     * @throws com.webapp.bankingportal.exception.UnauthorizedException if the password or old PIN is incorrect
+     * @throws com.webapp.bankingportal.exception.InvalidPinException   if the new PIN format is invalid
+     */
+    void updatePin(String accountNumber, String oldPIN, String password, String newPIN);
+
+    /**
+     * Deposits a cash amount into an account after verifying the PIN.
+     *
+     * @param accountNumber the target account number
+     * @param pin           the 4-digit PIN authorizing the deposit
+     * @param amount        the amount to deposit (must be positive, a multiple of 100, and at most 100,000)
+     * @throws com.webapp.bankingportal.exception.InvalidAmountException if the amount violates the deposit rules
+     * @throws com.webapp.bankingportal.exception.UnauthorizedException  if the PIN is invalid
+     */
+    void cashDeposit(String accountNumber, String pin, double amount);
+
+    /**
+     * Withdraws a cash amount from an account after verifying the PIN and checking the balance.
+     *
+     * @param accountNumber the source account number
+     * @param pin           the 4-digit PIN authorizing the withdrawal
+     * @param amount        the amount to withdraw (must be positive, a multiple of 100, and at most 100,000)
+     * @throws com.webapp.bankingportal.exception.InvalidAmountException      if the amount violates the withdrawal rules
+     * @throws com.webapp.bankingportal.exception.InsufficientBalanceException if the account does not have enough funds
+     * @throws com.webapp.bankingportal.exception.UnauthorizedException        if the PIN is invalid
+     */
+    void cashWithdrawal(String accountNumber, String pin, double amount);
+
+    /**
+     * Transfers funds from one account to another after verifying the source account PIN.
+     *
+     * @param sourceAccountNumber the account number to debit
+     * @param targetAccountNumber the account number to credit
+     * @param pin                 the 4-digit PIN of the source account
+     * @param amount              the amount to transfer (must be positive, a multiple of 100, and at most 100,000)
+     * @throws com.webapp.bankingportal.exception.FundTransferException        if the source and target accounts are the same
+     * @throws com.webapp.bankingportal.exception.NotFoundException             if the target account does not exist
+     * @throws com.webapp.bankingportal.exception.InsufficientBalanceException if the source account lacks sufficient funds
+     * @throws com.webapp.bankingportal.exception.UnauthorizedException        if the PIN is invalid
+     */
+    void fundTransfer(String sourceAccountNumber, String targetAccountNumber, String pin, double amount);
+
 }

--- a/src/main/java/com/webapp/bankingportal/service/AccountServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/AccountServiceImpl.java
@@ -26,6 +26,13 @@ import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Default implementation of {@link AccountService}.
+ *
+ * <p>Handles account creation, PIN lifecycle management, and the three types
+ * of fund movements (deposit, withdrawal, fund transfer). All state-changing
+ * operations are wrapped in database transactions to ensure atomicity.</p>
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -56,16 +63,29 @@ public class AccountServiceImpl implements AccountService {
         return account.getPin() != null;
     }
 
+    /**
+     * Generates a unique 6-character account number by repeatedly producing random
+     * UUID-derived strings until one that does not already exist in the database is found.
+     *
+     * @return a unique 6-character alphanumeric account number
+     */
     private String generateUniqueAccountNumber() {
         String accountNumber;
         do {
-            // Generate a UUID as the account number
             accountNumber = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 6);
         } while (accountRepository.findByAccountNumber(accountNumber) != null);
 
         return accountNumber;
     }
 
+    /**
+     * Validates that the provided PIN matches the stored hashed PIN for the given account.
+     *
+     * @param accountNumber the account number whose PIN is to be checked
+     * @param pin           the plain-text PIN to verify
+     * @throws NotFoundException     if the account does not exist
+     * @throws UnauthorizedException if no PIN has been set, the PIN is blank, or the PIN does not match
+     */
     private void validatePin(String accountNumber, String pin) {
         val account = accountRepository.findByAccountNumber(accountNumber);
         if (account == null) {
@@ -85,6 +105,15 @@ public class AccountServiceImpl implements AccountService {
         }
     }
 
+    /**
+     * Validates that the provided password matches the hashed password of the user
+     * who owns the given account.
+     *
+     * @param accountNumber the account number whose owner's password is to be checked
+     * @param password      the plain-text password to verify
+     * @throws NotFoundException     if the account does not exist
+     * @throws UnauthorizedException if the password is blank or does not match
+     */
     private void validatePassword(String accountNumber, String password) {
         val account = accountRepository.findByAccountNumber(accountNumber);
         if (account == null) {
@@ -142,6 +171,13 @@ public class AccountServiceImpl implements AccountService {
         accountRepository.save(account);
     }
 
+    /**
+     * Validates that a transaction amount satisfies the business rules:
+     * must be positive, a multiple of 100, and no greater than 100,000.
+     *
+     * @param amount the amount to validate
+     * @throws InvalidAmountException if any rule is violated
+     */
     private void validateAmount(double amount) {
         if (amount <= 0) {
             throw new InvalidAmountException(ApiMessages.AMOUNT_NEGATIVE_ERROR.getMessage());

--- a/src/main/java/com/webapp/bankingportal/service/AuthService.java
+++ b/src/main/java/com/webapp/bankingportal/service/AuthService.java
@@ -7,17 +7,73 @@ import com.webapp.bankingportal.dto.OtpVerificationRequest;
 import com.webapp.bankingportal.dto.ResetPasswordRequest;
 import com.webapp.bankingportal.entity.User;
 
+/**
+ * Service contract for the password-reset authentication flow.
+ *
+ * <p>The typical flow is:
+ * <ol>
+ *   <li>User requests an OTP via {@link #sendOtpForPasswordReset}.</li>
+ *   <li>User submits the OTP; a one-time reset token is issued via
+ *       {@link #verifyOtpAndIssueResetToken}.</li>
+ *   <li>User submits the reset token and their new password via
+ *       {@link #resetPassword}.</li>
+ * </ol>
+ * </p>
+ */
 public interface AuthService {
-    public String generatePasswordResetToken(User user);
 
-    public boolean verifyPasswordResetToken(String token, User user);
+    /**
+     * Generates (or reuses an existing valid) password-reset token for the given user.
+     *
+     * <p>If an unexpired token exists for the user it is returned directly;
+     * otherwise a new UUID token is created and persisted.</p>
+     *
+     * @param user the user requesting a password reset
+     * @return the opaque reset token string
+     */
+    String generatePasswordResetToken(User user);
 
-    public void deletePasswordResetToken(String token);
+    /**
+     * Verifies that the provided reset token is valid for the given user and
+     * has not expired, then deletes the token to prevent reuse.
+     *
+     * @param token the reset token to verify
+     * @param user  the user who is expected to own the token
+     * @return {@code true} if the token is valid and belongs to {@code user}, {@code false} otherwise
+     */
+    boolean verifyPasswordResetToken(String token, User user);
 
-    public ResponseEntity<String> sendOtpForPasswordReset(OtpRequest otpRequest);
+    /**
+     * Permanently deletes the password-reset token identified by the given string.
+     *
+     * @param token the reset token to delete
+     */
+    void deletePasswordResetToken(String token);
 
-    public ResponseEntity<String> verifyOtpAndIssueResetToken(OtpVerificationRequest otpVerificationRequest);
+    /**
+     * Generates a new OTP and sends it to the email address associated with
+     * the identifier in the request.
+     *
+     * @param otpRequest request containing the user identifier (email or account number)
+     * @return {@code 200 OK} with a success message, or {@code 500} on email delivery failure
+     */
+    ResponseEntity<String> sendOtpForPasswordReset(OtpRequest otpRequest);
 
-    public ResponseEntity<String> resetPassword(ResetPasswordRequest resetPasswordRequest);
+    /**
+     * Validates the OTP submitted by the user and, on success, issues a
+     * single-use password-reset token.
+     *
+     * @param otpVerificationRequest request containing the identifier and OTP
+     * @return {@code 200 OK} with the reset token, or {@code 401} if the OTP is invalid
+     */
+    ResponseEntity<String> verifyOtpAndIssueResetToken(OtpVerificationRequest otpVerificationRequest);
+
+    /**
+     * Resets the user's password after verifying the one-time reset token.
+     *
+     * @param resetPasswordRequest request containing the identifier, reset token, and new password
+     * @return {@code 200 OK} on success, {@code 401} for invalid token, or {@code 500} on failure
+     */
+    ResponseEntity<String> resetPassword(ResetPasswordRequest resetPasswordRequest);
 
 }

--- a/src/main/java/com/webapp/bankingportal/service/AuthServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/AuthServiceImpl.java
@@ -20,11 +20,18 @@ import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Default implementation of {@link AuthService}.
+ *
+ * <p>Orchestrates the OTP-based password-reset flow: OTP generation and dispatch,
+ * OTP verification and reset-token issuance, and the final password update.</p>
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
+    /** Number of hours before a password-reset token expires. */
     private static final int EXPIRATION_HOURS = 24;
 
     private final OtpService otpService;
@@ -107,10 +114,25 @@ public class AuthServiceImpl implements AuthService {
         }
     }
 
+    /**
+     * Returns {@code true} if an existing {@link PasswordResetToken} is non-null and still
+     * has more than 5 minutes of validity remaining.
+     *
+     * @param existingToken the token to evaluate, or {@code null}
+     * @return {@code true} if the token is present and sufficiently valid for reuse
+     */
     private boolean isExistingTokenValid(PasswordResetToken existingToken) {
         return existingToken != null && existingToken.getExpiryDateTime().isAfter(LocalDateTime.now().plusMinutes(5));
     }
 
+    /**
+     * Sends the OTP to the user's email address and returns the appropriate HTTP response.
+     *
+     * @param user          the user who will receive the OTP
+     * @param accountNumber the account number associated with the user
+     * @param generatedOtp  the OTP to include in the email
+     * @return {@code 200 OK} on successful dispatch, or {@code 500} on email delivery failure
+     */
     private ResponseEntity<String> sendOtpEmail(User user, String accountNumber, String generatedOtp) {
         val emailSendingFuture = otpService.sendOTPByEmail(user.getEmail(), user.getName(), accountNumber,
                 generatedOtp);
@@ -124,6 +146,12 @@ public class AuthServiceImpl implements AuthService {
                 .exceptionally(e -> failureResponse).join();
     }
 
+    /**
+     * Validates that the identifier and OTP fields of an {@link OtpVerificationRequest} are non-null and non-empty.
+     *
+     * @param otpVerificationRequest the request to validate
+     * @throws IllegalArgumentException if either field is missing
+     */
     private void validateOtpRequest(OtpVerificationRequest otpVerificationRequest) {
         if (otpVerificationRequest.identifier() == null || otpVerificationRequest.identifier().isEmpty()) {
             throw new IllegalArgumentException(ApiMessages.IDENTIFIER_MISSING_ERROR.getMessage());

--- a/src/main/java/com/webapp/bankingportal/service/CacheService.java
+++ b/src/main/java/com/webapp/bankingportal/service/CacheService.java
@@ -3,17 +3,68 @@ package com.webapp.bankingportal.service;
 import com.webapp.bankingportal.type.CacheKeyType;
 import java.util.Optional;
 
+/**
+ * Service contract for interacting with the Redis-backed cache store.
+ *
+ * <p>All cache operations are keyed using a {@link CacheKeyType} enum value,
+ * which encapsulates the key pattern, default TTL, and value type. Variable
+ * key segments are supplied via the {@code keyArguments} varargs parameter.</p>
+ */
 public interface CacheService {
-    
+
+    /**
+     * Returns {@code true} if a value exists in the cache for the computed key.
+     *
+     * @param cacheKeyType the key type defining the key pattern
+     * @param keyArguments variable arguments substituted into the key pattern
+     * @return {@code true} if the key is present, {@code false} otherwise
+     */
     boolean exists(CacheKeyType cacheKeyType, String... keyArguments);
 
+    /**
+     * Retrieves a string value from the cache.
+     *
+     * @param cacheKeyType the key type defining the key pattern
+     * @param keyArguments variable arguments substituted into the key pattern
+     * @return an {@link Optional} containing the string value, or empty if not found
+     */
     Optional<String> get(CacheKeyType cacheKeyType, String... keyArguments);
 
+    /**
+     * Retrieves a typed value from the cache, casting it to the requested class.
+     *
+     * @param <T>          the expected return type
+     * @param cacheKeyType the key type defining the key pattern
+     * @param clazz        the class to cast the cached value to
+     * @param keyArguments variable arguments substituted into the key pattern
+     * @return an {@link Optional} containing the typed value, or empty if not found or type mismatch
+     */
     <T> Optional<T> get(CacheKeyType cacheKeyType, Class<T> clazz, String... keyArguments);
 
+    /**
+     * Stores a value in the cache using the default TTL defined by {@code cacheKeyType}.
+     *
+     * @param cacheKeyType the key type defining the key pattern and TTL
+     * @param value        the value to cache
+     * @param keyArguments variable arguments substituted into the key pattern
+     */
     void put(CacheKeyType cacheKeyType, Object value, String... keyArguments);
 
+    /**
+     * Stores a value in the cache with an explicit TTL override.
+     *
+     * @param cacheKeyType the key type defining the key pattern
+     * @param value        the value to cache
+     * @param ttlSeconds   the number of seconds before the entry expires
+     * @param keyArguments variable arguments substituted into the key pattern
+     */
     void put(CacheKeyType cacheKeyType, Object value, long ttlSeconds, String... keyArguments);
 
+    /**
+     * Removes the cache entry for the computed key.
+     *
+     * @param cacheKeyType the key type defining the key pattern
+     * @param keyArguments variable arguments substituted into the key pattern
+     */
     void delete(CacheKeyType cacheKeyType, String... keyArguments);
 }

--- a/src/main/java/com/webapp/bankingportal/service/CacheServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/CacheServiceImpl.java
@@ -9,11 +9,19 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
+/**
+ * Redis-backed implementation of {@link CacheService}.
+ *
+ * <p>Uses a {@link RedisTemplate} configured with JSON serialization for values
+ * and string serialization for keys. All operations gracefully handle Redis
+ * unavailability by logging errors and returning empty optionals where possible.</p>
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CacheServiceImpl implements CacheService {
 
+    /** Redis template used for all cache read/write operations. */
     private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
@@ -84,6 +92,14 @@ public class CacheServiceImpl implements CacheService {
         }
     }
 
+    /**
+     * Computes the final cache key by formatting the {@code cacheKeyType}'s pattern with
+     * any provided arguments, or returns the bare pattern when no arguments are given.
+     *
+     * @param cacheKeyType the key type whose pattern is used
+     * @param keyArguments variable arguments substituted into the key pattern
+     * @return the resolved cache key string
+     */
     private String acquireKey(CacheKeyType cacheKeyType, String... keyArguments) {
         String key = cacheKeyType.generateKey();
         if (keyArguments.length != 0) {

--- a/src/main/java/com/webapp/bankingportal/service/DashboardService.java
+++ b/src/main/java/com/webapp/bankingportal/service/DashboardService.java
@@ -3,7 +3,26 @@ package com.webapp.bankingportal.service;
 import com.webapp.bankingportal.dto.AccountResponse;
 import com.webapp.bankingportal.dto.UserResponse;
 
+/**
+ * Service contract for retrieving user and account summary data for the dashboard.
+ */
 public interface DashboardService {
+
+    /**
+     * Returns a read-only view of the user associated with the given account number.
+     *
+     * @param accountNumber the account number whose owner details are requested
+     * @return a {@link UserResponse} containing user and account information
+     * @throws com.webapp.bankingportal.exception.NotFoundException if no user is linked to the account number
+     */
     UserResponse getUserDetails(String accountNumber);
+
+    /**
+     * Returns a read-only view of the account identified by the given account number.
+     *
+     * @param accountNumber the account number to look up
+     * @return an {@link AccountResponse} containing account details
+     * @throws com.webapp.bankingportal.exception.NotFoundException if no account matches the given number
+     */
     AccountResponse getAccountDetails(String accountNumber);
 }

--- a/src/main/java/com/webapp/bankingportal/service/DashboardServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/DashboardServiceImpl.java
@@ -13,6 +13,12 @@ import com.webapp.bankingportal.util.ApiMessages;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
+/**
+ * Default implementation of {@link DashboardService}.
+ *
+ * <p>Fetches user and account data from their respective repositories
+ * and returns read-only DTO projections suitable for the dashboard API.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class DashboardServiceImpl implements DashboardService {

--- a/src/main/java/com/webapp/bankingportal/service/EmailService.java
+++ b/src/main/java/com/webapp/bankingportal/service/EmailService.java
@@ -4,14 +4,50 @@ import java.util.concurrent.CompletableFuture;
 
 import org.springframework.scheduling.annotation.Async;
 
+/**
+ * Service contract for composing and sending HTML emails.
+ */
 public interface EmailService {
 
+    /**
+     * Sends an HTML email to the specified recipient asynchronously.
+     *
+     * @param to      the recipient's email address
+     * @param subject the email subject line
+     * @param text    the HTML body of the email
+     * @return a {@link CompletableFuture} that completes when delivery succeeds,
+     *         or completes exceptionally on failure
+     */
     @Async
-    public CompletableFuture<Void> sendEmail(String to, String subject, String text);
+    CompletableFuture<Void> sendEmail(String to, String subject, String text);
 
-    public String getLoginEmailTemplate(String name, String loginTime, String loginLocation);
+    /**
+     * Builds the HTML login-notification email body informing the user of a
+     * new login attempt.
+     *
+     * @param name          the recipient's display name
+     * @param loginTime     human-readable timestamp of the login attempt
+     * @param loginLocation human-readable city and country string, or {@code "Unknown"}
+     * @return the HTML email body as a string
+     */
+    String getLoginEmailTemplate(String name, String loginTime, String loginLocation);
 
-    public String getOtpLoginEmailTemplate(String name, String accountNumber, String otp);
+    /**
+     * Builds the HTML OTP email body containing the one-time password.
+     *
+     * @param name          the recipient's display name
+     * @param accountNumber the partially masked account number shown in the email
+     * @param otp           the 6-digit OTP to include
+     * @return the HTML email body as a string
+     */
+    String getOtpLoginEmailTemplate(String name, String accountNumber, String otp);
 
-    public String getBankStatementEmailTemplate(String name, String statementText);
+    /**
+     * Builds the HTML bank statement email body containing the plain-text statement.
+     *
+     * @param name          the recipient's display name
+     * @param statementText the plain-text bank statement content
+     * @return the HTML email body as a string
+     */
+    String getBankStatementEmailTemplate(String name, String statementText);
 }

--- a/src/main/java/com/webapp/bankingportal/service/EmailServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/EmailServiceImpl.java
@@ -14,6 +14,14 @@ import jakarta.mail.MessagingException;
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Default implementation of {@link EmailService} using Spring's {@link JavaMailSender}.
+ *
+ * <p>All emails are sent as HTML MIME messages. The {@link #sendEmail} method
+ * runs asynchronously (annotated with {@link org.springframework.scheduling.annotation.Async})
+ * and returns a {@link java.util.concurrent.CompletableFuture} that callers can use
+ * to react to success or failure without blocking.</p>
+ */
 @Service
 @Slf4j
 public class EmailServiceImpl implements EmailService {
@@ -113,6 +121,17 @@ public class EmailServiceImpl implements EmailService {
                 "</div>";
     }
 
+    /**
+     * Sends an HTML email with a file attachment.
+     *
+     * <p>This method is synchronous and does not return a {@link java.util.concurrent.CompletableFuture}.
+     * Errors are logged but not propagated to the caller.</p>
+     *
+     * @param to                 the recipient's email address
+     * @param subject            the email subject line
+     * @param text               the HTML email body
+     * @param attachmentFilePath the absolute path of the file to attach
+     */
     public void sendEmailWithAttachment(String to, String subject, String text, String attachmentFilePath) {
         try {
             val message = mailSender.createMimeMessage();

--- a/src/main/java/com/webapp/bankingportal/service/GeolocationService.java
+++ b/src/main/java/com/webapp/bankingportal/service/GeolocationService.java
@@ -6,8 +6,19 @@ import org.springframework.scheduling.annotation.Async;
 
 import com.webapp.bankingportal.dto.GeolocationResponse;
 
+/**
+ * Service contract for resolving an IP address to a geographic location.
+ */
 public interface GeolocationService {
 
+    /**
+     * Resolves the city and country for the given IP address by calling the
+     * external geolocation API asynchronously.
+     *
+     * @param ip the IPv4 or IPv6 address to resolve
+     * @return a {@link CompletableFuture} containing the {@link GeolocationResponse},
+     *         or completing exceptionally if the IP is invalid or the API call fails
+     */
     @Async
-    public CompletableFuture<GeolocationResponse> getGeolocation(String ip);
+    CompletableFuture<GeolocationResponse> getGeolocation(String ip);
 }

--- a/src/main/java/com/webapp/bankingportal/service/GeolocationServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/GeolocationServiceImpl.java
@@ -16,13 +16,22 @@ import com.webapp.bankingportal.exception.GeolocationException;
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Default implementation of {@link GeolocationService}.
+ *
+ * <p>Calls the external IP geolocation REST API configured via {@code geo.api.url}
+ * and {@code geo.api.key} to resolve a given IP address to a city and country.
+ * The call is made asynchronously so it does not block the login response path.</p>
+ */
 @Service
 @Slf4j
 public class GeolocationServiceImpl implements GeolocationService {
 
+    /** Base URL of the external geolocation API (injected from application properties). */
     @Value("${geo.api.url}")
     private String apiUrl;
 
+    /** API key for authenticating with the external geolocation service. */
     @Value("${geo.api.key}")
     private String apiKey;
 

--- a/src/main/java/com/webapp/bankingportal/service/OtpService.java
+++ b/src/main/java/com/webapp/bankingportal/service/OtpService.java
@@ -2,11 +2,45 @@ package com.webapp.bankingportal.service;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Service contract for generating, sending, and validating one-time passwords (OTPs).
+ */
 public interface OtpService {
 
-	String generateOTP(String accountNumber);
+    /**
+     * Generates a 6-digit OTP for the given account and stores it in the database.
+     *
+     * <p>If a valid, unexpired OTP already exists for the account, the existing OTP
+     * is refreshed (its timestamp is updated) and returned instead of creating a new one.
+     * OTP generation is rate-limited; an exception is thrown if the retry limit is exceeded.</p>
+     *
+     * @param accountNumber the account number for which an OTP is being generated
+     * @return the 6-digit OTP string
+     * @throws com.webapp.bankingportal.exception.AccountDoesNotExistException   if the account is not found
+     * @throws com.webapp.bankingportal.exception.OtpRetryLimitExceededException if too many OTPs have been requested
+     */
+    String generateOTP(String accountNumber);
 
-	public CompletableFuture<Void> sendOTPByEmail(String email,String name,String accountNumber, String otp) ;	
-	public boolean validateOTP(String accountNumber, String otp);
+    /**
+     * Sends the OTP to the specified email address asynchronously using an HTML email template.
+     *
+     * @param email         the recipient's email address
+     * @param name          the recipient's display name used in the email greeting
+     * @param accountNumber the account number (partially masked in the email body)
+     * @param otp           the OTP value to include in the email
+     * @return a {@link CompletableFuture} that completes when the email has been sent,
+     *         or completes exceptionally on delivery failure
+     */
+    CompletableFuture<Void> sendOTPByEmail(String email, String name, String accountNumber, String otp);
+
+    /**
+     * Validates that the given OTP matches the stored value for the account and has not expired.
+     *
+     * @param accountNumber the account number whose OTP is being validated
+     * @param otp           the OTP value to check
+     * @return {@code true} if the OTP is correct and still valid
+     * @throws com.webapp.bankingportal.exception.InvalidOtpException if no matching OTP record is found
+     */
+    boolean validateOTP(String accountNumber, String otp);
 
 }

--- a/src/main/java/com/webapp/bankingportal/service/OtpServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/OtpServiceImpl.java
@@ -19,13 +19,29 @@ import com.webapp.bankingportal.util.ApiMessages;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
+/**
+ * Default implementation of {@link OtpService}.
+ *
+ * <p>Manages OTP generation, caching of attempt counts, expiry checking,
+ * and asynchronous email delivery. OTP generation is rate-limited:
+ * after {@value #OTP_ATTEMPTS_LIMIT} attempts within a
+ * {@value #OTP_RETRY_LIMIT_WINDOW_MINUTES}-minute window the user must wait
+ * {@value #OTP_RESET_WAITING_TIME_MINUTES} minutes before retrying.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class OtpServiceImpl implements OtpService {
 
+    /** Maximum number of OTP generation attempts before the retry limit kicks in. */
     public static final int OTP_ATTEMPTS_LIMIT = 3;
+
+    /** Number of minutes after which an unused OTP expires. */
     public static final int OTP_EXPIRY_MINUTES = 5;
+
+    /** Cool-down period in minutes before OTP generation is allowed again after hitting the limit. */
     public static final int OTP_RESET_WAITING_TIME_MINUTES = 10;
+
+    /** Sliding window in minutes within which OTP attempt counts are tracked. */
     public static final int OTP_RETRY_LIMIT_WINDOW_MINUTES = 15;
 
     private final CacheManager cacheManager;
@@ -60,6 +76,12 @@ public class OtpServiceImpl implements OtpService {
         return existingOtpInfo.getOtp();
     }
 
+    /**
+     * Throws {@link OtpRetryLimitExceededException} if the account has exceeded
+     * the OTP generation limit within the current retry window.
+     *
+     * @param otpInfo the existing OTP record for the account
+     */
     private void validateOtpWithinRetryLimit(OtpInfo otpInfo) {
         if (!isOtpRetryLimitExceeded(otpInfo)) {
             return;
@@ -77,6 +99,13 @@ public class OtpServiceImpl implements OtpService {
                 String.format(ApiMessages.OTP_GENERATION_LIMIT_EXCEEDED.getMessage(), waitingMinutes));
     }
 
+    /**
+     * Returns {@code true} if the account has reached the maximum number of OTP attempts
+     * within the retry window and the cool-down period has not yet elapsed.
+     *
+     * @param otpInfo the OTP record for the account
+     * @return {@code true} if the retry limit is exceeded, {@code false} otherwise
+     */
     private boolean isOtpRetryLimitExceeded(OtpInfo otpInfo) {
         val attempts = getOtpAttempts(otpInfo.getAccountNumber());
         if (attempts < OTP_ATTEMPTS_LIMIT) {
@@ -93,12 +122,23 @@ public class OtpServiceImpl implements OtpService {
         return otpInfo.getGeneratedAt().isAfter(now.minusMinutes(OTP_RETRY_LIMIT_WINDOW_MINUTES));
     }
 
+    /**
+     * Returns {@code true} if the cool-down period since the limit was first reached has elapsed.
+     *
+     * @return {@code true} if enough time has passed to reset the OTP attempt counter
+     */
     private boolean isOtpResetWaitingTimeExceeded() {
         val now = LocalDateTime.now();
         return otpLimitReachedTime != null
                 && otpLimitReachedTime.isBefore(now.minusMinutes(OTP_RESET_WAITING_TIME_MINUTES));
     }
 
+    /**
+     * Increments the cached OTP attempt counter for the given account by one.
+     *
+     * @param accountNumber the account number whose attempt counter should be incremented
+     * @throws AccountDoesNotExistException if the account is not found
+     */
     private void incrementOtpAttempts(String accountNumber) {
         if (!validationUtil.doesAccountExist(accountNumber)) {
             throw new AccountDoesNotExistException(ApiMessages.ACCOUNT_NOT_FOUND.getMessage());
@@ -110,6 +150,12 @@ public class OtpServiceImpl implements OtpService {
         }
     }
 
+    /**
+     * Resets the cached OTP attempt counter for the given account to zero and
+     * clears the limit-reached timestamp.
+     *
+     * @param accountNumber the account number whose attempt counter should be reset
+     */
     private void resetOtpAttempts(String accountNumber) {
         otpLimitReachedTime = null;
         val cache = cacheManager.getCache("otpAttempts");
@@ -118,6 +164,13 @@ public class OtpServiceImpl implements OtpService {
         }
     }
 
+    /**
+     * Returns the current OTP attempt count for the given account from the cache.
+     * Returns {@code 0} if no entry exists or the cache is unavailable.
+     *
+     * @param accountNumber the account number to look up
+     * @return the current attempt count, or {@code 0}
+     */
     private int getOtpAttempts(String accountNumber) {
         var otpAttempts = 0;
         val cache = cacheManager.getCache("otpAttempts");
@@ -133,6 +186,12 @@ public class OtpServiceImpl implements OtpService {
         return otpAttempts;
     }
 
+    /**
+     * Generates a new random 6-digit OTP, persists it for the given account, and returns it.
+     *
+     * @param accountNumber the account number for which the OTP is generated
+     * @return the newly generated 6-digit OTP string
+     */
     private String generateNewOTP(String accountNumber) {
         val random = new Random();
         val otpValue = 100_000 + random.nextInt(900_000);
@@ -159,6 +218,12 @@ public class OtpServiceImpl implements OtpService {
         return !isOtpExpired(otpInfo);
     }
 
+    /**
+     * Checks whether an OTP has exceeded its validity period and deletes the record if expired.
+     *
+     * @param otpInfo the OTP record to check
+     * @return {@code true} if the OTP has expired (and was deleted), {@code false} if still valid
+     */
     private boolean isOtpExpired(OtpInfo otpInfo) {
         val now = LocalDateTime.now();
         val generatedAt = otpInfo.getGeneratedAt();

--- a/src/main/java/com/webapp/bankingportal/service/TokenService.java
+++ b/src/main/java/com/webapp/bankingportal/service/TokenService.java
@@ -10,22 +10,80 @@ import com.webapp.bankingportal.exception.InvalidTokenException;
 
 import io.jsonwebtoken.Claims;
 
+/**
+ * Service contract for JWT token lifecycle management, also implementing
+ * {@link UserDetailsService} so that Spring Security can load user details
+ * from the token subject during request authentication.
+ */
 public interface TokenService extends UserDetailsService {
 
-    public String generateToken(UserDetails userDetails);
+    /**
+     * Generates a signed JWT for the given user using the configured default expiration.
+     *
+     * @param userDetails the principal whose username becomes the token subject
+     * @return a compact, URL-safe JWT string
+     */
+    String generateToken(UserDetails userDetails);
 
-    public String generateToken(UserDetails userDetails, Date expiry);
+    /**
+     * Generates a signed JWT for the given user with an explicit expiry timestamp.
+     *
+     * @param userDetails the principal whose username becomes the token subject
+     * @param expiry      the exact timestamp at which the token expires
+     * @return a compact, URL-safe JWT string
+     */
+    String generateToken(UserDetails userDetails, Date expiry);
 
-    public String getUsernameFromToken(String token) throws InvalidTokenException;
+    /**
+     * Extracts the username (account number) from a JWT.
+     *
+     * @param token the compact JWT string
+     * @return the subject claim, which is the account number
+     * @throws InvalidTokenException if the token is expired, malformed, or otherwise invalid
+     */
+    String getUsernameFromToken(String token) throws InvalidTokenException;
 
-    public Date getExpirationDateFromToken(String token) throws InvalidTokenException;
+    /**
+     * Extracts the expiration timestamp from a JWT.
+     *
+     * @param token the compact JWT string
+     * @return the expiration {@link Date}
+     * @throws InvalidTokenException if the token is expired, malformed, or otherwise invalid
+     */
+    Date getExpirationDateFromToken(String token) throws InvalidTokenException;
 
-    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver)
-            throws InvalidTokenException;
+    /**
+     * Extracts an arbitrary claim from a JWT using the provided resolver function.
+     *
+     * @param <T>            the type of the resolved claim value
+     * @param token          the compact JWT string
+     * @param claimsResolver a function that maps the full {@link Claims} object to the desired value
+     * @return the resolved claim value
+     * @throws InvalidTokenException if the token is expired, malformed, or otherwise invalid
+     */
+    <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) throws InvalidTokenException;
 
-    public void saveToken(String token) throws InvalidTokenException;
+    /**
+     * Persists a newly generated JWT to the database for server-side revocation tracking.
+     *
+     * @param token the compact JWT string to persist
+     * @throws InvalidTokenException if the token is already present in the database or is invalid
+     */
+    void saveToken(String token) throws InvalidTokenException;
 
-    public void validateToken(String token) throws InvalidTokenException;
+    /**
+     * Validates that the given JWT exists in the database (i.e., has not been revoked).
+     *
+     * @param token the compact JWT string to validate
+     * @throws InvalidTokenException if the token is not found in the database
+     */
+    void validateToken(String token) throws InvalidTokenException;
 
-    public void invalidateToken(String token);
+    /**
+     * Removes the given JWT from the database, effectively revoking the session.
+     * If the token is not found, the call is silently ignored.
+     *
+     * @param token the compact JWT string to invalidate
+     */
+    void invalidateToken(String token);
 }

--- a/src/main/java/com/webapp/bankingportal/service/TokenServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/TokenServiceImpl.java
@@ -27,14 +27,24 @@ import lombok.RequiredArgsConstructor;
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Default implementation of {@link TokenService}.
+ *
+ * <p>Handles JWT creation, parsing, persistence, and revocation using the
+ * JJWT library. Tokens are signed with HMAC-SHA-512 using a Base64-encoded
+ * secret configured via {@code jwt.secret}. Expiry is configured via
+ * {@code jwt.expiration} (milliseconds).</p>
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class TokenServiceImpl implements TokenService {
 
+    /** Base64-encoded HMAC-SHA-512 signing secret injected from application properties. */
     @Value("${jwt.secret}")
     private String secret;
 
+    /** Token lifetime in milliseconds, injected from application properties. */
     @Value("${jwt.expiration}")
     private long expiration;
 
@@ -59,10 +69,23 @@ public class TokenServiceImpl implements TokenService {
         log.info("Generating token for user: " + userDetails.getUsername());
         return doGenerateToken(userDetails, expiry);
     }
+    /**
+     * Decodes the Base64 secret and returns the HMAC-SHA signing key.
+     *
+     * @return the {@link Key} used to sign and verify JWTs
+     */
     private Key key() {
         byte[] keyBytes = Decoders.BASE64.decode(secret);
         return Keys.hmacShaKeyFor(keyBytes);
     }
+
+    /**
+     * Builds and signs a JWT with the given principal and expiry time.
+     *
+     * @param userDetails the principal whose username becomes the subject claim
+     * @param expiry      the exact expiration timestamp
+     * @return a compact, signed JWT string
+     */
     private String doGenerateToken(UserDetails userDetails, Date expiry) {
         return Jwts.builder().setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date())
@@ -91,11 +114,26 @@ public class TokenServiceImpl implements TokenService {
         val claims = getAllClaimsFromToken(token);
         return claimsResolver.apply(claims);
     }
+    /**
+     * Builds a {@link JwtParser} configured with the application's signing key.
+     *
+     * @return a ready-to-use JWT parser
+     */
     private JwtParser parser() {
         return Jwts.parserBuilder()
                 .setSigningKey(key())
                 .build();
     }
+
+    /**
+     * Parses the JWT and returns all claims. Translates JJWT-specific exceptions
+     * into {@link InvalidTokenException}.
+     *
+     * @param token the compact JWT string to parse
+     * @return the full {@link Claims} payload
+     * @throws InvalidTokenException if the token is expired, unsupported, malformed,
+     *                               has an invalid signature, or is empty
+     */
     private Claims getAllClaimsFromToken(String token) throws InvalidTokenException {
         try {
            // return Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();

--- a/src/main/java/com/webapp/bankingportal/service/TransactionService.java
+++ b/src/main/java/com/webapp/bankingportal/service/TransactionService.java
@@ -4,9 +4,27 @@ import java.util.List;
 
 import com.webapp.bankingportal.dto.TransactionDTO;
 
+/**
+ * Service contract for retrieving transaction history and delivering bank statements.
+ */
 public interface TransactionService {
 
-	List<TransactionDTO> getAllTransactionsByAccountNumber(String accountNumber);
-	void sendBankStatementByEmail(String accountNumber);
+    /**
+     * Returns a list of all transactions in which the given account was either
+     * the source or the target, sorted in reverse chronological order.
+     *
+     * @param accountNumber the account number whose transactions are to be fetched
+     * @return a non-null, possibly empty list of {@link TransactionDTO} objects
+     */
+    List<TransactionDTO> getAllTransactionsByAccountNumber(String accountNumber);
+
+    /**
+     * Sends a plain-text bank statement for the given account to the account
+     * holder's registered email address.
+     *
+     * @param accountNumber the account number whose statement is to be emailed
+     * @throws IllegalArgumentException if {@code accountNumber} is null or blank
+     */
+    void sendBankStatementByEmail(String accountNumber);
 
 }

--- a/src/main/java/com/webapp/bankingportal/service/TransactionServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/TransactionServiceImpl.java
@@ -13,6 +13,12 @@ import com.webapp.bankingportal.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
+/**
+ * Default implementation of {@link TransactionService}.
+ *
+ * <p>Retrieves transaction history from the database and composes
+ * bank-statement emails for the account holder.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class TransactionServiceImpl implements TransactionService {

--- a/src/main/java/com/webapp/bankingportal/service/UserService.java
+++ b/src/main/java/com/webapp/bankingportal/service/UserService.java
@@ -11,30 +11,111 @@ import com.webapp.bankingportal.exception.InvalidTokenException;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+/**
+ * Service contract for user account registration, authentication, and profile management.
+ */
 public interface UserService {
 
-    public ResponseEntity<String> registerUser(User user);
+    /**
+     * Validates, persists, and activates a new user together with an associated bank account.
+     *
+     * @param user the new user to register (password will be BCrypt-encoded before storage)
+     * @return {@code 200 OK} with a {@link com.webapp.bankingportal.dto.UserResponse UserResponse} JSON body
+     * @throws com.webapp.bankingportal.exception.UserInvalidException if validation fails or the email/phone already exists
+     */
+    ResponseEntity<String> registerUser(User user);
 
-    public ResponseEntity<String> login(LoginRequest loginRequest, HttpServletRequest request)
+    /**
+     * Authenticates a user using their password, sends a login-notification email,
+     * and issues a JWT.
+     *
+     * @param loginRequest the login credentials (identifier + password)
+     * @param request      the incoming HTTP request, used to extract the client IP for geolocation
+     * @return {@code 200 OK} with a JSON body containing the issued JWT
+     * @throws InvalidTokenException if token generation or persistence fails
+     */
+    ResponseEntity<String> login(LoginRequest loginRequest, HttpServletRequest request)
             throws InvalidTokenException;
 
-    public ResponseEntity<String> generateOtp(OtpRequest otpRequest);
+    /**
+     * Generates an OTP for the account identified by the request and sends it by email.
+     *
+     * @param otpRequest request containing the user identifier (email or account number)
+     * @return {@code 200 OK} on successful dispatch, or {@code 500} on email failure
+     */
+    ResponseEntity<String> generateOtp(OtpRequest otpRequest);
 
-    public ResponseEntity<String> verifyOtpAndLogin(OtpVerificationRequest otpVerificationRequest)
+    /**
+     * Validates an OTP and, on success, issues a JWT for the authenticated user.
+     *
+     * @param otpVerificationRequest request containing the identifier and OTP
+     * @return {@code 200 OK} with a JSON body containing the issued JWT
+     * @throws InvalidTokenException if token generation or persistence fails
+     * @throws com.webapp.bankingportal.exception.UnauthorizedException if the OTP is invalid
+     */
+    ResponseEntity<String> verifyOtpAndLogin(OtpVerificationRequest otpVerificationRequest)
             throws InvalidTokenException;
 
-    public ResponseEntity<String> updateUser(User user);
+    /**
+     * Updates the profile of the currently authenticated user after verifying their password.
+     *
+     * @param user the updated user data (password field is used for identity verification)
+     * @return {@code 200 OK} with a {@link com.webapp.bankingportal.dto.UserResponse UserResponse} JSON body
+     */
+    ResponseEntity<String> updateUser(User user);
 
-    public ModelAndView logout(String token) throws InvalidTokenException;
+    /**
+     * Invalidates the JWT supplied in the Authorization header and redirects to the logout page.
+     *
+     * @param token the full Authorization header value (must start with {@code "Bearer "})
+     * @return a redirect {@link ModelAndView} to {@code /logout}
+     * @throws InvalidTokenException if the token is not found or is invalid
+     */
+    ModelAndView logout(String token) throws InvalidTokenException;
 
-    public boolean resetPassword(User user, String newPassword);
+    /**
+     * Replaces the user's current password with the given new password (BCrypt-encoded).
+     *
+     * @param user        the user whose password is to be reset
+     * @param newPassword the new plain-text password to encode and store
+     * @return {@code true} if the password was successfully reset
+     * @throws com.webapp.bankingportal.exception.PasswordResetException if persistence fails
+     */
+    boolean resetPassword(User user, String newPassword);
 
-    public User saveUser(User user);
+    /**
+     * Persists (creates or updates) a {@link User} entity in the database.
+     *
+     * @param user the user to save
+     * @return the saved user entity
+     */
+    User saveUser(User user);
 
-    public User getUserByIdentifier(String identifier);
+    /**
+     * Looks up a user by either their email address or account number.
+     *
+     * @param identifier the email address or 6-digit account number
+     * @return the matching {@link User}
+     * @throws com.webapp.bankingportal.exception.UserInvalidException if no user matches the identifier
+     */
+    User getUserByIdentifier(String identifier);
 
-    public User getUserByAccountNumber(String accountNo);
+    /**
+     * Looks up a user by their associated account number.
+     *
+     * @param accountNo the 6-digit account number
+     * @return the matching {@link User}
+     * @throws com.webapp.bankingportal.exception.UserInvalidException if no user is linked to the account number
+     */
+    User getUserByAccountNumber(String accountNo);
 
-    public User getUserByEmail(String email);
+    /**
+     * Looks up a user by their email address.
+     *
+     * @param email the email address to search for
+     * @return the matching {@link User}
+     * @throws com.webapp.bankingportal.exception.UserInvalidException if no user has that email
+     */
+    User getUserByEmail(String email);
 
 }

--- a/src/main/java/com/webapp/bankingportal/service/UserServiceImpl.java
+++ b/src/main/java/com/webapp/bankingportal/service/UserServiceImpl.java
@@ -34,6 +34,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Default implementation of {@link UserService}.
+ *
+ * <p>Handles user registration, password-based and OTP-based authentication,
+ * profile updates, logout, and password reset. Login events trigger an
+ * asynchronous geolocation lookup and notification email.</p>
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -152,17 +159,36 @@ public class UserServiceImpl implements UserService {
                 () -> new UserInvalidException(String.format(ApiMessages.USER_NOT_FOUND_BY_EMAIL.getMessage(), email)));
     }
 
+    /**
+     * BCrypt-encodes the user's password in place and uppercases their country code.
+     *
+     * @param user the user whose password and country code are to be normalized
+     */
     private void encodePassword(User user) {
         user.setCountryCode(user.getCountryCode().toUpperCase());
         user.setPassword(passwordEncoder.encode(user.getPassword()));
     }
 
+    /**
+     * Persists the user and then immediately creates and links a new bank account for them.
+     *
+     * @param user the user to persist (password must already be encoded)
+     * @return the saved user with a populated {@link com.webapp.bankingportal.entity.Account} reference
+     */
     private User saveUserWithAccount(User user) {
         val savedUser = saveUser(user);
         savedUser.setAccount(accountService.createAccount(savedUser));
         return saveUser(savedUser);
     }
 
+    /**
+     * Resolves the user from the login request identifier and authenticates against
+     * Spring Security's {@link org.springframework.security.authentication.AuthenticationManager}.
+     *
+     * @param loginRequest the login credentials
+     * @return the authenticated {@link com.webapp.bankingportal.entity.User}
+     * @throws org.springframework.security.authentication.BadCredentialsException if authentication fails
+     */
     private User authenticateUser(LoginRequest loginRequest) {
         val user = getUserByIdentifier(loginRequest.identifier());
         val accountNumber = user.getAccount().getAccountNumber();
@@ -171,10 +197,24 @@ public class UserServiceImpl implements UserService {
         return user;
     }
 
+    /**
+     * Authenticates using an explicit account number and password without resolving by identifier.
+     *
+     * @param accountNumber the account number to authenticate
+     * @param password      the plain-text password to verify
+     * @throws org.springframework.security.authentication.BadCredentialsException if authentication fails
+     */
     private void authenticateUser(String accountNumber, String password) {
         authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(accountNumber, password));
     }
 
+    /**
+     * Generates a new JWT for the given account number and persists it to the database.
+     *
+     * @param accountNumber the account number for which the token is issued
+     * @return the raw JWT string
+     * @throws InvalidTokenException if token generation or persistence fails
+     */
     private String generateAndSaveToken(String accountNumber) throws InvalidTokenException {
         val userDetails = userDetailsService.loadUserByUsername(accountNumber);
         val token = tokenService.generateToken(userDetails);
@@ -182,6 +222,14 @@ public class UserServiceImpl implements UserService {
         return token;
     }
 
+    /**
+     * Sends the OTP to the user's email and wraps the async result into a synchronous
+     * HTTP response.
+     *
+     * @param user the user who will receive the OTP email
+     * @param otp  the OTP to include in the email
+     * @return {@code 200 OK} on successful dispatch, or {@code 500} on failure
+     */
     private ResponseEntity<String> sendOtpEmail(User user, String otp) {
         val emailSendingFuture = otpService.sendOTPByEmail(
                 user.getEmail(), user.getName(), user.getAccount().getAccountNumber(), otp);
@@ -195,6 +243,12 @@ public class UserServiceImpl implements UserService {
                 .exceptionally(e -> failureResponse).join();
     }
 
+    /**
+     * Validates that the identifier and OTP fields of an {@link OtpVerificationRequest} are non-null and non-empty.
+     *
+     * @param request the request to validate
+     * @throws IllegalArgumentException if either field is blank
+     */
     private void validateOtpRequest(OtpVerificationRequest request) {
         if (request.identifier() == null || request.identifier().isEmpty()) {
             throw new IllegalArgumentException(ApiMessages.IDENTIFIER_MISSING_ERROR.getMessage());
@@ -204,18 +258,40 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    /**
+     * Validates the OTP submitted for a user's account and throws an exception if invalid.
+     *
+     * @param user the user whose account OTP is being checked
+     * @param otp  the OTP value to validate
+     * @throws com.webapp.bankingportal.exception.UnauthorizedException if the OTP is invalid or expired
+     */
     private void validateOtp(User user, String otp) {
         if (!otpService.validateOTP(user.getAccount().getAccountNumber(), otp)) {
             throw new UnauthorizedException(ApiMessages.OTP_INVALID_ERROR.getMessage());
         }
     }
 
+    /**
+     * Applies the changes from {@code updatedUser} onto {@code existingUser} after
+     * validation, preserving the existing password (since it is verified separately).
+     *
+     * @param existingUser the current user record to update
+     * @param updatedUser  the incoming user data containing the new field values
+     */
     private void updateUserDetails(User existingUser, User updatedUser) {
         ValidationUtil.validateUserDetails(updatedUser);
         updatedUser.setPassword(existingUser.getPassword());
         userMapper.updateUser(updatedUser, existingUser);
     }
 
+    /**
+     * Asynchronously resolves the IP to a geographic location and sends a login-notification
+     * email to the user. Falls back to location "Unknown" if geolocation fails.
+     *
+     * @param user the user who just logged in
+     * @param ip   the remote IP address from the HTTP request
+     * @return a {@link CompletableFuture} that resolves to {@code true} on successful email delivery
+     */
     private CompletableFuture<Boolean> sendLoginNotification(User user, String ip) {
         val loginTime = new Timestamp(System.currentTimeMillis()).toString();
 
@@ -229,6 +305,14 @@ public class UserServiceImpl implements UserService {
                 .exceptionallyComposeAsync(throwable -> sendLoginEmail(user, loginTime, "Unknown"));
     }
 
+    /**
+     * Builds and sends the HTML login-notification email.
+     *
+     * @param user          the user who logged in
+     * @param loginTime     formatted timestamp of the login
+     * @param loginLocation resolved city/country string, or "Unknown"
+     * @return a {@link CompletableFuture} resolving to {@code true} on success, {@code false} on failure
+     */
     private CompletableFuture<Boolean> sendLoginEmail(User user, String loginTime, String loginLocation) {
         val emailText = emailService.getLoginEmailTemplate(user.getName(), loginTime, loginLocation);
         return emailService.sendEmail(user.getEmail(), ApiMessages.EMAIL_SUBJECT_LOGIN.getMessage(), emailText)

--- a/src/main/java/com/webapp/bankingportal/type/CacheKeyType.java
+++ b/src/main/java/com/webapp/bankingportal/type/CacheKeyType.java
@@ -3,20 +3,50 @@ package com.webapp.bankingportal.type;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Enumeration of all cache key types used by the banking portal.
+ *
+ * <p>Each constant encapsulates the key pattern (a {@link String#format} template),
+ * the default TTL in seconds, and the expected value type. This centralises cache
+ * key construction and prevents typos.</p>
+ */
 @Getter
 @RequiredArgsConstructor
 public enum CacheKeyType {
+
+    /**
+     * Key type for idempotency tokens used to deduplicate state-changing API requests.
+     * Pattern: {@code IDPT:<accountNumber>:<endpoint>:<requestHash>}
+     * TTL: 86400 seconds (24 hours).
+     */
     IDEMPOTENCY("IDPT:%s:%s:%s", 86400, CacheValueType.JSON),
     ;
 
+    /** {@link String#format} pattern used to build the fully qualified cache key. */
     private final String prefix;
+
+    /** Default time-to-live in seconds for entries stored under this key type. */
     private final long ttlSeconds;
+
+    /** Expected serialization format for the cached value. */
     private final CacheValueType cacheValueType;
 
+    /**
+     * Returns the raw key pattern without any argument substitution.
+     * Useful when no variable segments are required.
+     *
+     * @return the unformatted key pattern string
+     */
     public String generateKey() {
         return prefix;
     }
 
+    /**
+     * Formats the key pattern with the supplied arguments.
+     *
+     * @param arguments the variable segments to substitute into the key pattern
+     * @return the fully qualified cache key string
+     */
     public String generateKey(String... arguments) {
         return String.format(prefix, (Object[]) arguments);
     }

--- a/src/main/java/com/webapp/bankingportal/type/CacheValueType.java
+++ b/src/main/java/com/webapp/bankingportal/type/CacheValueType.java
@@ -1,7 +1,15 @@
 package com.webapp.bankingportal.type;
 
+/**
+ * Enumeration describing the serialization format expected for a cached value.
+ *
+ * <p>Used by {@link CacheKeyType} to indicate how values stored under a given key
+ * type should be serialized and deserialized.</p>
+ */
 public enum CacheValueType {
+    /** Plain string value, stored and retrieved without additional serialization. */
     STRING,
+    /** JSON-encoded value, serialized and deserialized using Jackson. */
     JSON,
     ;
 }

--- a/src/main/java/com/webapp/bankingportal/util/ApiMessages.java
+++ b/src/main/java/com/webapp/bankingportal/util/ApiMessages.java
@@ -3,6 +3,14 @@ package com.webapp.bankingportal.util;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Centralised enumeration of all user-facing message strings used across the application.
+ *
+ * <p>Using an enum rather than scattered string literals ensures consistency,
+ * prevents typos, and makes messages easy to localise in the future.
+ * Messages that contain format specifiers (e.g., {@code %s}, {@code %d}) must be
+ * formatted with {@link String#format} before use.</p>
+ */
 @RequiredArgsConstructor
 public enum ApiMessages {
     ACCOUNT_NOT_FOUND("Account does not exist"),

--- a/src/main/java/com/webapp/bankingportal/util/ValidationUtil.java
+++ b/src/main/java/com/webapp/bankingportal/util/ValidationUtil.java
@@ -18,6 +18,13 @@ import jakarta.mail.internet.InternetAddress;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
+/**
+ * Utility class providing validation helpers for user registration and profile updates.
+ *
+ * <p>Static methods perform format validation (email, phone number, country code,
+ * password complexity) and can be used without a Spring context. Instance methods
+ * perform database-backed uniqueness checks and require dependency injection.</p>
+ */
 @Component
 @RequiredArgsConstructor
 public class ValidationUtil {
@@ -27,6 +34,12 @@ public class ValidationUtil {
 
     private final UserRepository userRepository;
 
+    /**
+     * Returns {@code true} if the given string is a syntactically valid email address.
+     *
+     * @param identifier the string to validate as an email address
+     * @return {@code true} if valid, {@code false} otherwise
+     */
     public static boolean isValidEmail(String identifier) {
         try {
             new InternetAddress(identifier).validate();
@@ -38,11 +51,22 @@ public class ValidationUtil {
         return false;
     }
 
+    /**
+     * Returns {@code true} if the given string is a valid 6-character account number.
+     *
+     * @param identifier the string to validate as an account number
+     * @return {@code true} if non-null and exactly 6 characters long
+     */
     public static boolean isValidAccountNumber(String identifier) {
-        // Account number validation logic (e.g., length check)
         return identifier != null && identifier.length() == 6;
     }
 
+    /**
+     * Returns {@code true} if the given country code is a recognized ISO 3166-1 alpha-2 region.
+     *
+     * @param countryCode the country code to validate (e.g., "US", "IN")
+     * @return {@code true} if the code is supported by {@link PhoneNumberUtil}
+     */
     public static boolean isValidCountryCode(String countryCode) {
         if (!phoneNumberUtil.getSupportedRegions().contains(countryCode)) {
             return false;
@@ -51,6 +75,14 @@ public class ValidationUtil {
         return true;
     }
 
+    /**
+     * Returns {@code true} if the given phone number is valid for the specified country.
+     *
+     * @param phoneNumber the national subscriber number to validate
+     * @param countryCode the ISO 3166-1 alpha-2 country code used for parsing
+     * @return {@code true} if the number is valid
+     * @throws com.webapp.bankingportal.exception.UserInvalidException if the number cannot be parsed
+     */
     public static boolean isValidPhoneNumber(String phoneNumber, String countryCode) {
         PhoneNumber parsedNumber = null;
 
@@ -63,6 +95,14 @@ public class ValidationUtil {
         return phoneNumberUtil.isValidNumber(parsedNumber);
     }
 
+    /**
+     * Validates that a plain-text password meets all complexity requirements:
+     * 8–127 characters, no whitespace, at least one uppercase letter, one lowercase
+     * letter, one digit, and one special character.
+     *
+     * @param password the plain-text password to validate
+     * @throws com.webapp.bankingportal.exception.UserInvalidException if any requirement is not met
+     */
     public static void validatePassword(String password) {
         if (password.length() < 8) {
             throw new UserInvalidException(ApiMessages.PASSWORD_TOO_SHORT_ERROR.getMessage());
@@ -117,6 +157,12 @@ public class ValidationUtil {
         }
     }
 
+    /**
+     * Checks that all required {@link com.webapp.bankingportal.entity.User User} fields are present and non-empty.
+     *
+     * @param user the user object to check
+     * @throws com.webapp.bankingportal.exception.UserInvalidException if the user is null or any required field is blank
+     */
     public static void validateUserDetailsNotEmpty(User user) {
         if (user == null) {
             throw new UserInvalidException(ApiMessages.USER_DETAILS_EMPTY_ERROR.getMessage());
@@ -147,6 +193,13 @@ public class ValidationUtil {
         }
     }
 
+    /**
+     * Validates all user details: checks for non-empty fields and then validates
+     * the email format, country code, phone number, and password complexity.
+     *
+     * @param user the user object to validate
+     * @throws com.webapp.bankingportal.exception.UserInvalidException if any field is invalid
+     */
     public static void validateUserDetails(User user) {
         validateUserDetailsNotEmpty(user);
 
@@ -165,6 +218,13 @@ public class ValidationUtil {
         validatePassword(user.getPassword());
     }
 
+    /**
+     * Validates user details and additionally checks that the email and phone number
+     * are not already registered in the database.
+     *
+     * @param user the new user to validate
+     * @throws com.webapp.bankingportal.exception.UserInvalidException if any field is invalid or the email/phone already exists
+     */
     public void validateNewUser(User user) {
         validateUserDetails(user);
         if (doesEmailExist(user.getEmail())) {
@@ -175,14 +235,32 @@ public class ValidationUtil {
         }
     }
 
+    /**
+     * Returns {@code true} if an account with the given account number exists in the database.
+     *
+     * @param accountNumber the account number to look up
+     * @return {@code true} if a matching account is found
+     */
     public boolean doesAccountExist(String accountNumber) {
         return userRepository.findByAccountAccountNumber(accountNumber).isPresent();
     }
 
+    /**
+     * Returns {@code true} if a user with the given email address already exists in the database.
+     *
+     * @param email the email address to check
+     * @return {@code true} if the email is already registered
+     */
     public boolean doesEmailExist(String email) {
         return userRepository.findByEmail(email).isPresent();
     }
 
+    /**
+     * Returns {@code true} if a user with the given phone number already exists in the database.
+     *
+     * @param phoneNumber the phone number to check
+     * @return {@code true} if the phone number is already registered
+     */
     public boolean doesPhoneNumberExist(String phoneNumber) {
         return userRepository.findByPhoneNumber(phoneNumber).isPresent();
     }


### PR DESCRIPTION
Solution for Git Issue Add Comprehensive Docstrings to Codebase #28

Comprehensive Javadoc has been added to all 75+ Java files in the codebase. The build compiles. Here's a summary of what was documented:

  Entities (Account, User, Transaction, Token, OtpInfo, PasswordResetToken, TransactionType): class-level summaries, field-level inline docs, constructor docs

  DTOs (all 10 records/classes): class-level summaries with @param tags on record components, constructor docs

  Service interfaces (all 10): detailed method contracts with @param, @return, and @throws documenting all exception types

  Service implementations (all 10): class-level summaries explaining responsibilities; all private helper methods documented

  Controllers (all 5 including GlobalExceptionHandler): class-level summaries; every endpoint and handler method documented with HTTP response codes

  Repositories (all 6): interface summaries; custom query methods documented

  Exception classes (all 13): class descriptions with the HTTP status code each maps to; constructor docs

  Config, Security, Mappers, Utils, Types, Main: class summaries; all @Bean methods, public methods, and enum constants documented